### PR TITLE
Add chat session interface for LangChain RAG

### DIFF
--- a/html/09.15 문의 관리.html
+++ b/html/09.15 문의 관리.html
@@ -845,78 +845,122 @@
     </div>
 
     <script>
-        // 전역 변수
+        const API_BASE_URL = window.API_BASE_URL || '';
         let inquiries = [];
-        let currentAdminUser = '김관리';
-        let adminUsers = [
-            { 
-                id: 'admin1', 
-                name: '김관리', 
-                email: 'kim@garampos.com', 
-                department: '고객지원팀',
-                assignedCount: 0,
-                completedCount: 0
-            },
-            { 
-                id: 'admin2', 
-                name: '이관리', 
-                email: 'lee@garampos.com', 
-                department: '기술지원팀',
-                assignedCount: 0,
-                completedCount: 0
-            },
-            { 
-                id: 'admin3', 
-                name: '박관리', 
-                email: 'park@garampos.com', 
-                department: '운영팀',
-                assignedCount: 0,
-                completedCount: 0
-            }
-        ];
+        let adminUsers = [];
+        let currentAdmin = null;
 
-        // DOM이 로드되면 실행
-        window.addEventListener('load', function() {
-            console.log('페이지 로드 완료');
+        window.addEventListener('load', () => {
             initializeApp();
         });
 
-        function initializeApp() {
+        async function initializeApp() {
             try {
-                // 샘플 데이터 로드
-                loadSampleInquiries();
-                
-                // 관리자 목록 렌더링
-                renderAdminGrid();
-                
-                // 통계 업데이트
-                updateStats();
-                
-                // 이벤트 리스너 등록
+                await refreshData();
                 setupEventListeners();
-                
                 console.log('앱 초기화 완료');
             } catch (error) {
                 console.error('초기화 오류:', error);
+                showToast(error.message || '데이터를 불러오는 중 오류가 발생했습니다.', 'error');
             }
         }
 
+        async function refreshData() {
+            await loadAdminUsers();
+            await loadInquiries();
+            updateAdminStats();
+            renderAdminGrid();
+            renderInquiries();
+            updateStats();
+            updateUserProfile();
+        }
+
+        function updateUserProfile() {
+            const userNameElement = document.querySelector('.user-name');
+            if (userNameElement) {
+                userNameElement.textContent = currentAdmin ? currentAdmin.name : '관리자';
+            }
+        }
+
+        async function loadAdminUsers() {
+            const data = await fetchJSON(`${API_BASE_URL}/admin_users?limit=100`);
+            adminUsers = data.map(admin => ({
+                id: admin.id,
+                name: admin.name,
+                email: admin.email,
+                department: admin.department,
+                assignedCount: 0,
+                completedCount: 0
+            }));
+
+            if (!currentAdmin || !adminUsers.some(admin => admin.id === currentAdmin.id)) {
+                currentAdmin = adminUsers.length > 0 ? adminUsers[0] : null;
+            }
+        }
+
+        async function loadInquiries() {
+            const [rawList, detailedList] = await Promise.all([
+                fetchJSON(`${API_BASE_URL}/inquiries?limit=100`),
+                fetchJSON(`${API_BASE_URL}/inquiries/get_inquiry_list`)
+            ]);
+
+            const detailById = new Map(detailedList.map(item => [item.id, item]));
+
+            inquiries = rawList.map(item => {
+                const detail = detailById.get(item.id) || {};
+                return {
+                    id: item.id,
+                    name: detail.name || item.customer_name,
+                    company: detail.company || item.company || '-',
+                    phone: detail.phone || item.phone || '-',
+                    content: detail.content || item.content || '',
+                    status: item.status,
+                    createdDate: detail.createdDate || formatDateTime(item.created_at),
+                    assignee: detail.assignee || getAdminNameById(item.assignee_admin_id),
+                    assignedDate: detail.assignedDate || formatDateTime(item.assigned_at),
+                    completedDate: detail.completedDate || formatDateTime(item.completed_at),
+                    history: Array.isArray(detail.history) ? detail.history : []
+                };
+            });
+        }
+
+        function formatDateTime(value) {
+            if (!value) return '';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return '';
+            }
+            const pad = (num) => num.toString().padStart(2, '0');
+            const year = date.getFullYear();
+            const month = pad(date.getMonth() + 1);
+            const day = pad(date.getDate());
+            const hours = pad(date.getHours());
+            const minutes = pad(date.getMinutes());
+            return `${year}-${month}-${day} ${hours}:${minutes}`;
+        }
+
+        function getAdminById(adminId) {
+            return adminUsers.find(admin => admin.id === adminId) || null;
+        }
+
+        function getAdminNameById(adminId) {
+            const admin = getAdminById(adminId);
+            return admin ? admin.name : null;
+        }
+
         function setupEventListeners() {
-            // 관리자 추가 폼 이벤트
             const addAdminForm = document.getElementById('addAdminForm');
             if (addAdminForm) {
-                addAdminForm.addEventListener('submit', function(e) {
-                    e.preventDefault();
-                    addNewAdmin();
+                addAdminForm.addEventListener('submit', async function(event) {
+                    event.preventDefault();
+                    await addNewAdmin();
                 });
             }
 
-            // 모달 외부 클릭 시 닫기
             document.addEventListener('click', function(e) {
                 if (e.target.classList.contains('modal')) {
                     closeAddAdminModal();
                 }
-                // 드롭다운 외부 클릭 시 닫기
                 if (!e.target.closest('.assign-dropdown')) {
                     closeAllDropdowns();
                 }
@@ -927,8 +971,20 @@
             const adminGrid = document.getElementById('adminGrid');
             if (!adminGrid) return;
 
+            if (adminUsers.length === 0) {
+                adminGrid.innerHTML = `
+                    <div class="empty-state">
+                        <div class="empty-icon">
+                            <i class="fas fa-users-slash"></i>
+                        </div>
+                        <p>등록된 관리자가 없습니다.</p>
+                    </div>
+                `;
+                return;
+            }
+
             adminGrid.innerHTML = adminUsers.map(admin => {
-                const isCurrentUser = admin.name === currentAdminUser;
+                const isCurrentUser = currentAdmin && currentAdmin.id === admin.id;
                 return `
                     <div class="admin-card ${isCurrentUser ? 'current' : ''}">
                         ${isCurrentUser ? '<div class="current-badge">현재 사용자</div>' : ''}
@@ -951,12 +1007,12 @@
                             </div>
                         </div>
                         <div class="admin-actions">
-                            ${!isCurrentUser ? `
-                                <button class="btn btn-sm btn-primary" onclick="switchToAdmin('${admin.name}')">
+                            ${!isCurrentUser && adminUsers.length > 0 ? `
+                                <button class="btn btn-sm btn-primary" onclick="switchToAdmin(${admin.id})">
                                     <i class="fas fa-exchange-alt"></i> 전환
                                 </button>
                             ` : ''}
-                            <button class="btn btn-sm btn-danger" onclick="removeAdmin('${admin.id}')" ${isCurrentUser ? 'disabled style="opacity: 0.5; cursor: not-allowed;"' : ''}>
+                            <button class="btn btn-sm btn-danger" onclick="removeAdmin(${admin.id})" ${isCurrentUser ? 'disabled style="opacity: 0.5; cursor: not-allowed;"' : ''}>
                                 <i class="fas fa-trash"></i> 삭제
                             </button>
                         </div>
@@ -965,23 +1021,20 @@
             }).join('');
         }
 
-        function switchToAdmin(adminName) {
-            currentAdminUser = adminName;
-            const userNameElement = document.querySelector('.user-name');
-            if (userNameElement) {
-                userNameElement.textContent = currentAdminUser;
-            }
-            
+        function switchToAdmin(adminId) {
+            const admin = getAdminById(adminId);
+            if (!admin) return;
+            currentAdmin = admin;
+            updateUserProfile();
             renderAdminGrid();
             renderInquiries();
-            showToast(`${adminName}으로 전환되었습니다.`, 'info');
+            showToast(`${admin.name}으로 전환되었습니다.`, 'info');
         }
 
         function openAddAdminModal() {
             const modal = document.getElementById('addAdminModal');
             if (modal) {
                 modal.classList.add('show');
-                // 폼 초기화
                 document.getElementById('adminName').value = '';
                 document.getElementById('adminEmail').value = '';
                 document.getElementById('adminDepartment').value = '';
@@ -995,7 +1048,7 @@
             }
         }
 
-        function addNewAdmin() {
+        async function addNewAdmin() {
             const name = document.getElementById('adminName').value.trim();
             const email = document.getElementById('adminEmail').value.trim();
             const department = document.getElementById('adminDepartment').value.trim() || '일반';
@@ -1005,157 +1058,68 @@
                 return;
             }
 
-            // 이메일 중복 확인
-            if (adminUsers.some(admin => admin.email === email)) {
-                showToast('이미 등록된 이메일입니다.', 'error');
+            const password = prompt('초기 비밀번호를 입력하세요:');
+            if (!password) {
+                showToast('비밀번호를 입력해야 합니다.', 'error');
                 return;
             }
 
-            // 새 관리자 추가
-            const newAdmin = {
-                id: 'admin' + (Date.now()),
-                name: name,
-                email: email,
-                department: department,
-                assignedCount: 0,
-                completedCount: 0
-            };
+            try {
+                await fetchJSON(`${API_BASE_URL}/admin_users`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name,
+                        email,
+                        department,
+                        password
+                    })
+                });
 
-            adminUsers.push(newAdmin);
-            renderAdminGrid();
-            closeAddAdminModal();
-            showToast(`${name} 관리자가 추가되었습니다.`, 'success');
+                await refreshData();
+                closeAddAdminModal();
+                showToast(`${name} 관리자가 추가되었습니다.`, 'success');
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '관리자 추가 중 오류가 발생했습니다.', 'error');
+            }
         }
 
-        function removeAdmin(adminId) {
-            const admin = adminUsers.find(a => a.id === adminId);
+        async function removeAdmin(adminId) {
+            const admin = getAdminById(adminId);
             if (!admin) return;
 
-            if (admin.name === currentAdminUser) {
+            if (currentAdmin && admin.id === currentAdmin.id) {
                 showToast('현재 사용자는 삭제할 수 없습니다.', 'error');
                 return;
             }
 
-            if (confirm(`${admin.name} 관리자를 삭제하시겠습니까?`)) {
-                // 해당 관리자에게 할당된 문의가 있는지 확인
-                const assignedInquiries = inquiries.filter(inq => inq.assignee === admin.name);
-                
-                if (assignedInquiries.length > 0) {
-                    if (!confirm(`${admin.name}에게 할당된 ${assignedInquiries.length}개의 문의가 있습니다. 정말 삭제하시겠습니까? (할당된 문의는 미할당 상태가 됩니다.)`)) {
-                        return;
-                    }
-                    
-                    // 할당된 문의들을 미할당 상태로 변경
-                    assignedInquiries.forEach(inq => {
-                        inq.assignee = null;
-                        inq.status = 'new';
-                        inq.history.push({
-                            action: '담당자 삭제로 인한 미할당',
-                            admin: '시스템',
-                            timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
-                            details: `${admin.name} 관리자 삭제로 인해 미할당 상태로 변경되었습니다.`
-                        });
-                    });
+            const assignedInquiries = inquiries.filter(inq => inq.assignee === admin.name);
+            if (assignedInquiries.length > 0) {
+                const confirmTransfer = confirm(`${admin.name}에게 할당된 ${assignedInquiries.length}개의 문의가 있습니다. 삭제하면 미할당 상태가 됩니다. 계속하시겠습니까?`);
+                if (!confirmTransfer) {
+                    return;
                 }
-
-                adminUsers = adminUsers.filter(a => a.id !== adminId);
-                renderAdminGrid();
-                renderInquiries();
-                updateStats();
-                showToast(`${admin.name} 관리자가 삭제되었습니다.`, 'success');
+            } else if (!confirm(`${admin.name} 관리자를 삭제하시겠습니까?`)) {
+                return;
             }
-        }
 
-        function loadSampleInquiries() {
-            inquiries = [
-                {
-                    id: 1,
-                    name: '홍길동',
-                    company: '가람포스텍',
-                    phone: '010-1234-5678',
-                    content: 'POS 시스템이 갑자기 꺼져서 재부팅을 해도 계속 같은 문제가 발생합니다. 긴급히 해결이 필요합니다.',
-                    status: 'new',
-                    createdDate: '2024-12-20 14:30',
-                    assignee: null,
-                    history: [
-                        {
-                            action: '문의 접수',
-                            admin: '시스템',
-                            timestamp: '2024-12-20 14:30',
-                            details: '챗봇을 통해 문의가 접수되었습니다.'
-                        }
-                    ]
-                },
-                {
-                    id: 2,
-                    name: '김영희',
-                    company: '스마트카페',
-                    phone: '010-2345-6789',
-                    content: '키오스크 터치 반응이 느려서 고객들이 불편해하고 있습니다. 설정 방법을 알려주세요.',
-                    status: 'processing',
-                    createdDate: '2024-12-20 13:15',
-                    assignee: '이관리',
-                    assignedDate: '2024-12-20 13:45',
-                    history: [
-                        {
-                            action: '문의 접수',
-                            admin: '시스템',
-                            timestamp: '2024-12-20 13:15',
-                            details: '챗봇을 통해 문의가 접수되었습니다.'
-                        },
-                        {
-                            action: '담당자 배정',
-                            admin: '이관리',
-                            timestamp: '2024-12-20 13:45',
-                            details: '이관리님이 문의를 담당하게 되었습니다.'
-                        }
-                    ]
-                },
-                {
-                    id: 3,
-                    name: '박철수',
-                    company: '베이커리하우스',
-                    phone: '010-3456-7890',
-                    content: '프린터에서 영수증이 출력되지 않습니다. 용지는 충분한 상태인데 어떻게 해야 할까요?',
-                    status: 'completed',
-                    createdDate: '2024-12-19 16:20',
-                    assignee: '김관리',
-                    assignedDate: '2024-12-19 16:30',
-                    completedDate: '2024-12-20 09:30',
-                    history: [
-                        {
-                            action: '문의 접수',
-                            admin: '시스템',
-                            timestamp: '2024-12-19 16:20',
-                            details: '챗봇을 통해 문의가 접수되었습니다.'
-                        },
-                        {
-                            action: '담당자 배정',
-                            admin: '김관리',
-                            timestamp: '2024-12-19 16:30',
-                            details: '김관리님이 문의를 담당하게 되었습니다.'
-                        },
-                        {
-                            action: '처리 완료',
-                            admin: '김관리',
-                            timestamp: '2024-12-20 09:30',
-                            details: '프린터 드라이버 재설치로 문제가 해결되었습니다.'
-                        }
-                    ]
-                }
-            ];
-            
-            // 관리자별 통계 업데이트
-            updateAdminStats();
-            renderInquiries();
+            try {
+                await fetchJSON(`${API_BASE_URL}/admin_users/${adminId}`, { method: 'DELETE' });
+                await refreshData();
+                showToast(`${admin.name} 관리자가 삭제되었습니다.`, 'success');
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '관리자 삭제 중 오류가 발생했습니다.', 'error');
+            }
         }
 
         function updateAdminStats() {
             adminUsers.forEach(admin => {
-                admin.assignedCount = inquiries.filter(inq => 
+                admin.assignedCount = inquiries.filter(inq =>
                     inq.assignee === admin.name && (inq.status === 'processing' || inq.status === 'on_hold')
                 ).length;
-                admin.completedCount = inquiries.filter(inq => 
+                admin.completedCount = inquiries.filter(inq =>
                     inq.assignee === admin.name && inq.status === 'completed'
                 ).length;
             });
@@ -1164,7 +1128,7 @@
         function renderInquiries() {
             const listContainer = document.getElementById('inquiryList');
             if (!listContainer) return;
-            
+
             if (inquiries.length === 0) {
                 listContainer.innerHTML = `
                     <div class="empty-state">
@@ -1187,7 +1151,7 @@
             const statusClass = {
                 'new': 'status-new',
                 'processing': 'status-processing',
-                'on_hold': 'status-on_hold', 
+                'on_hold': 'status-on_hold',
                 'completed': 'status-completed'
             };
 
@@ -1212,6 +1176,32 @@
                     </div>
                 `).join('');
 
+                const assignOptions = adminUsers.length > 0
+                    ? adminUsers.map(admin => `
+                        <div class="assign-dropdown-item" onclick="assignInquiry(${inquiry.id}, ${admin.id})">
+                            <div class="admin-avatar">${admin.name.charAt(0)}</div>
+                            <div>
+                                <div style="font-weight: 600;">${admin.name}</div>
+                                <div style="font-size: 0.75rem; color: var(--text-secondary);">${admin.department}</div>
+                            </div>
+                        </div>
+                    `).join('')
+                    : '<div class="assign-dropdown-item" style="cursor: default;">등록된 관리자가 없습니다.</div>';
+
+                const transferOptions = adminUsers
+                    .filter(admin => !currentAdmin || admin.id !== currentAdmin.id)
+                    .map(admin => `
+                        <div class="assign-dropdown-item" onclick="transferInquiry(${inquiry.id}, ${admin.id})">
+                            <div class="admin-avatar">${admin.name.charAt(0)}</div>
+                            <div>
+                                <div style="font-weight: 600;">${admin.name}</div>
+                                <div style="font-size: 0.75rem; color: var(--text-secondary);">${admin.department}</div>
+                            </div>
+                        </div>
+                    `).join('');
+
+                const isCurrentAssignee = currentAdmin && inquiry.assignee === currentAdmin.name;
+
                 let actionButtons = '';
                 if (inquiry.status === 'new') {
                     actionButtons = `
@@ -1220,19 +1210,11 @@
                                 <i class="fas fa-user-plus"></i> 담당자 지정
                             </button>
                             <div class="assign-dropdown-menu" id="dropdown-${inquiry.id}">
-                                ${adminUsers.map(admin => `
-                                    <div class="assign-dropdown-item" onclick="assignInquiry(${inquiry.id}, '${admin.name}')">
-                                        <div class="admin-avatar">${admin.name.charAt(0)}</div>
-                                        <div>
-                                            <div style="font-weight: 600;">${admin.name}</div>
-                                            <div style="font-size: 0.75rem; color: var(--text-secondary);">${admin.department}</div>
-                                        </div>
-                                    </div>
-                                `).join('')}
+                                ${assignOptions}
                             </div>
                         </div>
                     `;
-                } else if (inquiry.status === 'processing' && inquiry.assignee === currentAdminUser) {
+                } else if (inquiry.status === 'processing' && isCurrentAssignee) {
                     actionButtons = `
                         <div class="action-buttons">
                             <button class="btn btn-info btn-sm" onclick="contactCustomer(${inquiry.id})"><i class="fas fa-phone"></i> 연락</button>
@@ -1243,21 +1225,13 @@
                                     <i class="fas fa-exchange-alt"></i> 이관
                                 </button>
                                 <div class="assign-dropdown-menu" id="transfer-dropdown-${inquiry.id}">
-                                    ${adminUsers.filter(admin => admin.name !== currentAdminUser).map(admin => `
-                                        <div class="assign-dropdown-item" onclick="transferInquiry(${inquiry.id}, '${admin.name}')">
-                                            <div class="admin-avatar">${admin.name.charAt(0)}</div>
-                                            <div>
-                                                <div style="font-weight: 600;">${admin.name}</div>
-                                                <div style="font-size: 0.75rem; color: var(--text-secondary);">${admin.department}</div>
-                                            </div>
-                                        </div>
-                                    `).join('')}
+                                    ${transferOptions || '<div class="assign-dropdown-item" style="cursor: default;">이관 가능한 관리자가 없습니다.</div>'}
                                 </div>
                             </div>
                             <button class="btn btn-success btn-sm" onclick="markAsCompleted(${inquiry.id})"><i class="fas fa-check"></i> 완료</button>
                         </div>
                     `;
-                } else if (inquiry.status === 'on_hold' && inquiry.assignee === currentAdminUser) {
+                } else if (inquiry.status === 'on_hold' && isCurrentAssignee) {
                     actionButtons = `
                         <div class="action-buttons">
                             <button class="btn btn-info btn-sm" onclick="resumeProcessing(${inquiry.id})"><i class="fas fa-play"></i> 재개</button>
@@ -1267,15 +1241,7 @@
                                     <i class="fas fa-exchange-alt"></i> 이관
                                 </button>
                                 <div class="assign-dropdown-menu" id="transfer-dropdown-${inquiry.id}">
-                                    ${adminUsers.filter(admin => admin.name !== currentAdminUser).map(admin => `
-                                        <div class="assign-dropdown-item" onclick="transferInquiry(${inquiry.id}, '${admin.name}')">
-                                            <div class="admin-avatar">${admin.name.charAt(0)}</div>
-                                            <div>
-                                                <div style="font-weight: 600;">${admin.name}</div>
-                                                <div style="font-size: 0.75rem; color: var(--text-secondary);">${admin.department}</div>
-                                            </div>
-                                        </div>
-                                    `).join('')}
+                                    ${transferOptions || '<div class="assign-dropdown-item" style="cursor: default;">이관 가능한 관리자가 없습니다.</div>'}
                                 </div>
                             </div>
                             <button class="btn btn-success btn-sm" onclick="markAsCompleted(${inquiry.id})"><i class="fas fa-check"></i> 완료</button>
@@ -1338,26 +1304,28 @@
             });
         }
 
-        function assignInquiry(inquiryId, adminName) {
-            const inquiry = inquiries.find(inq => inq.id === inquiryId);
-            if (inquiry && inquiry.status === 'new') {
-                inquiry.status = 'processing';
-                inquiry.assignee = adminName;
-                inquiry.assignedDate = new Date().toISOString().slice(0, 16).replace('T', ' ');
-                
-                inquiry.history.push({
-                    action: '담당자 배정',
-                    admin: currentAdminUser,
-                    timestamp: inquiry.assignedDate,
-                    details: `${adminName}님이 문의를 담당하게 되었습니다.`
+        async function assignInquiry(inquiryId, adminId) {
+            const admin = getAdminById(adminId);
+            if (!admin) {
+                showToast('선택한 관리자를 찾을 수 없습니다.', 'error');
+                return;
+            }
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${inquiryId}/assign`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        admin_id: adminId,
+                        actor_admin_id: currentAdmin ? currentAdmin.id : null
+                    })
                 });
-
-                updateAdminStats();
-                renderAdminGrid();
-                renderInquiries();
-                updateStats();
+                showToast(`${admin.name}님에게 문의가 배정되었습니다.`, 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '문의 배정 중 오류가 발생했습니다.', 'error');
+            } finally {
                 closeAllDropdowns();
-                showToast(`${adminName}님에게 문의가 배정되었습니다.`, 'info');
             }
         }
 
@@ -1380,146 +1348,252 @@
             }
         }
 
-        // 나머지 함수들 (기존과 동일)
-        function contactCustomer(id) {
+        async function contactCustomer(id) {
             const inquiry = inquiries.find(inq => inq.id === id);
-            if (inquiry && inquiry.assignee === currentAdminUser) {
-                const contactMethod = prompt('연락 방법을 선택하세요:\n1. 전화\n2. 이메일\n3. SMS\n번호를 입력하세요:');
-                if (contactMethod) {
-                    const methodText = {'1': '전화', '2': '이메일', '3': 'SMS'}[contactMethod] || '기타';
-                    const contactNote = prompt('연락 내용을 입력하세요:');
-                    
-                    if (contactNote) {
-                        inquiry.history.push({
-                            action: '고객 연락',
-                            admin: currentAdminUser,
-                            timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
-                            details: `${methodText}로 연락 - ${contactNote}`
-                        });
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name) {
+                return;
+            }
 
-                        renderInquiries();
-                        showToast(`${methodText}로 고객에게 연락했습니다.`, 'info');
-                    }
-                }
+            const contactMethod = prompt('연락 방법을 선택하세요:\n1. 전화\n2. 이메일\n3. SMS\n번호를 입력하세요:');
+            if (!contactMethod) {
+                return;
+            }
+
+            const methodText = { '1': '전화', '2': '이메일', '3': 'SMS' }[contactMethod] || '기타';
+            const contactNote = prompt('연락 내용을 입력하세요:');
+            if (!contactNote) {
+                return;
+            }
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/histories/note`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        admin_id: currentAdmin.id,
+                        details: `${methodText}로 연락 - ${contactNote}`
+                    })
+                });
+                showToast(`${methodText}로 고객에게 연락했습니다.`, 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '연락 기록 저장 중 오류가 발생했습니다.', 'error');
             }
         }
 
-        function addMemo(id) {
+        async function addMemo(id) {
             const inquiry = inquiries.find(inq => inq.id === id);
-            if (inquiry && inquiry.assignee === currentAdminUser) {
-                const memo = prompt('처리 메모를 입력하세요:');
-                if (memo) {
-                    inquiry.history.push({
-                        action: '메모 추가',
-                        admin: currentAdminUser,
-                        timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name) {
+                return;
+            }
+
+            const memo = prompt('처리 메모를 입력하세요:');
+            if (!memo) {
+                return;
+            }
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/histories/note`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        admin_id: currentAdmin.id,
                         details: memo
-                    });
-
-                    renderInquiries();
-                    showToast('메모가 추가되었습니다.', 'info');
-                }
+                    })
+                });
+                showToast('메모가 추가되었습니다.', 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '메모 추가 중 오류가 발생했습니다.', 'error');
             }
         }
 
-        function setOnHold(id) {
+        async function setOnHold(id) {
             const inquiry = inquiries.find(inq => inq.id === id);
-            if (inquiry && inquiry.assignee === currentAdminUser) {
-                const reason = prompt('대기 사유를 입력하세요:');
-                if (reason) {
-                    inquiry.status = 'on_hold';
-                    inquiry.history.push({
-                        action: '처리 대기',
-                        admin: currentAdminUser,
-                        timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name) {
+                return;
+            }
+
+            const reason = prompt('대기 사유를 입력하세요:');
+            if (!reason) {
+                return;
+            }
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/status`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        status: 'on_hold',
+                        actor_admin_id: currentAdmin.id,
                         details: reason
-                    });
-
-                    updateAdminStats();
-                    renderAdminGrid();
-                    renderInquiries();
-                    updateStats();
-                    showToast('문의가 대기 상태로 변경되었습니다.', 'info');
-                }
+                    })
+                });
+                showToast('문의가 대기 상태로 변경되었습니다.', 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '대기 처리 중 오류가 발생했습니다.', 'error');
             }
         }
 
-        function resumeProcessing(id) {
+        async function resumeProcessing(id) {
             const inquiry = inquiries.find(inq => inq.id === id);
-            if (inquiry && inquiry.assignee === currentAdminUser && inquiry.status === 'on_hold') {
-                inquiry.status = 'processing';
-                inquiry.history.push({
-                    action: '처리 재개',
-                    admin: currentAdminUser,
-                    timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
-                    details: '대기 상태에서 처리를 재개했습니다.'
-                });
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name || inquiry.status !== 'on_hold') {
+                return;
+            }
 
-                updateAdminStats();
-                renderAdminGrid();
-                renderInquiries();
-                updateStats();
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/status`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        status: 'processing',
+                        actor_admin_id: currentAdmin.id,
+                        details: '대기 상태에서 처리를 재개했습니다.'
+                    })
+                });
                 showToast('문의 처리를 재개합니다.', 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '처리 재개 중 오류가 발생했습니다.', 'error');
             }
         }
 
-        function transferInquiry(inquiryId, newAssignee) {
+        async function transferInquiry(inquiryId, newAdminId) {
             const inquiry = inquiries.find(inq => inq.id === inquiryId);
-            if (inquiry && inquiry.assignee === currentAdminUser) {
-                const reason = prompt('이관 사유를 입력하세요:');
-                const oldAssignee = inquiry.assignee;
-                
-                inquiry.assignee = newAssignee;
-                inquiry.history.push({
-                    action: '담당자 이관',
-                    admin: currentAdminUser,
-                    timestamp: new Date().toISOString().slice(0, 16).replace('T', ' '),
-                    details: `${oldAssignee} → ${newAssignee} (사유: ${reason || '없음'})`
+            const newAdmin = getAdminById(newAdminId);
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name || !newAdmin) {
+                return;
+            }
+
+            const reason = prompt('이관 사유를 입력하세요:');
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${inquiryId}/transfer`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        to_admin_id: newAdminId,
+                        actor_admin_id: currentAdmin.id
+                    })
                 });
 
-                updateAdminStats();
-                renderAdminGrid();
-                renderInquiries();
-                closeAllDropdowns();
-                showToast(`${newAssignee}님에게 이관되었습니다.`, 'info');
-            }
-        }
-
-        function markAsCompleted(id) {
-            const inquiry = inquiries.find(inq => inq.id === id);
-            if (inquiry && (inquiry.status === 'processing' || inquiry.status === 'on_hold') && inquiry.assignee === currentAdminUser) {
-                const response = prompt('처리 결과를 입력해주세요:');
-                if (response) {
-                    const customerSatisfied = confirm('고객이 만족했습니까?');
-                    
-                    inquiry.status = 'completed';
-                    inquiry.completedDate = new Date().toISOString().slice(0, 16).replace('T', ' ');
-                    inquiry.customerSatisfaction = customerSatisfied;
-                    
-                    inquiry.history.push({
-                        action: '처리 완료',
-                        admin: currentAdminUser,
-                        timestamp: inquiry.completedDate,
-                        details: `${response} (고객 만족도: ${customerSatisfied ? '만족' : '불만족'})`
+                if (reason) {
+                    await fetchJSON(`${API_BASE_URL}/inquiries/${inquiryId}/histories/note`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            admin_id: currentAdmin.id,
+                            details: `이관 사유: ${reason}`
+                        })
                     });
-
-                    updateAdminStats();
-                    renderAdminGrid();
-                    renderInquiries();
-                    updateStats();
-                    showToast('문의가 완료 처리되었습니다.', 'success');
                 }
+
+                showToast(`${newAdmin.name}님에게 이관되었습니다.`, 'info');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '문의 이관 중 오류가 발생했습니다.', 'error');
+            } finally {
+                closeAllDropdowns();
             }
         }
 
-        function deleteInquiry(id) {
-            if (confirm('이 문의를 삭제하시겠습니까?')) {
-                inquiries = inquiries.filter(inq => inq.id !== id);
-                updateAdminStats();
-                renderAdminGrid();
-                renderInquiries();
-                updateStats();
+        async function markAsCompleted(id) {
+            const inquiry = inquiries.find(inq => inq.id === id);
+            if (!inquiry || !currentAdmin || inquiry.assignee !== currentAdmin.name || (inquiry.status !== 'processing' && inquiry.status !== 'on_hold')) {
+                return;
+            }
+
+            const response = prompt('처리 결과를 입력해주세요:');
+            if (!response) {
+                return;
+            }
+
+            const customerSatisfied = confirm('고객이 만족했습니까? (확인=만족, 취소=불만족)');
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/status`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        status: 'completed',
+                        actor_admin_id: currentAdmin.id,
+                        details: response
+                    })
+                });
+
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}/satisfaction`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        satisfaction: customerSatisfied ? 'satisfied' : 'unsatisfied'
+                    })
+                });
+
+                showToast('문의가 완료 처리되었습니다.', 'success');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '완료 처리 중 오류가 발생했습니다.', 'error');
+            }
+        }
+
+        async function deleteInquiry(id) {
+            if (!confirm('이 문의를 삭제하시겠습니까?')) {
+                return;
+            }
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/inquiries/${id}`, { method: 'DELETE' });
                 showToast('문의가 삭제되었습니다.', 'success');
+                await refreshData();
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '문의 삭제 중 오류가 발생했습니다.', 'error');
+            }
+        }
+
+        async function fetchJSON(url, options = {}) {
+            try {
+                const response = await fetch(url, options);
+                if (!response.ok) {
+                    let message = `HTTP ${response.status}`;
+                    try {
+                        const data = await response.json();
+                        if (data?.detail) {
+                            message = data.detail;
+                        } else if (typeof data === 'string') {
+                            message = data;
+                        }
+                    } catch (jsonError) {
+                        // ignore json parse error
+                    }
+                    throw new Error(message);
+                }
+
+                if (response.status === 204) {
+                    return null;
+                }
+
+                const text = await response.text();
+                if (!text) {
+                    return null;
+                }
+                try {
+                    return JSON.parse(text);
+                } catch (parseError) {
+                    return null;
+                }
+            } catch (error) {
+                if (error instanceof Error) {
+                    throw error;
+                }
+                throw new Error('네트워크 오류가 발생했습니다.');
             }
         }
 
@@ -1527,13 +1601,13 @@
             const toast = document.createElement('div');
             toast.className = `toast ${type}`;
             toast.textContent = message;
-            
+
             document.body.appendChild(toast);
-            
+
             setTimeout(() => {
                 toast.classList.add('show');
             }, 100);
-            
+
             setTimeout(() => {
                 toast.classList.remove('show');
                 setTimeout(() => {

--- a/html/chat_session.html
+++ b/html/chat_session.html
@@ -1,0 +1,1244 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>가람포스텍 RAG 상담 센터</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57jzv4N3GdP0pG5dQ3V7R3HgNbwe+58YF0UHvP7jv0A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <style>
+        :root {
+            --primary: #1e60e1;
+            --primary-dark: #1546a5;
+            --secondary: #f1f5f9;
+            --surface: #ffffff;
+            --text-primary: #1f2933;
+            --text-secondary: #64748b;
+            --border: #e2e8f0;
+            --danger: #dc2626;
+            --success: #16a34a;
+            --shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.08);
+            --transition: all 0.2s ease-in-out;
+            --sidebar-width: 320px;
+            --context-width: 320px;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            height: 100%;
+            margin: 0;
+            font-family: 'Noto Sans KR', sans-serif;
+            background: #eef2f7;
+            color: var(--text-primary);
+        }
+
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .app-shell {
+            flex: 1;
+            display: grid;
+            grid-template-columns: var(--sidebar-width) minmax(0, 1fr) var(--context-width);
+            grid-template-rows: 100%;
+            min-height: 0;
+        }
+
+        aside,
+        main {
+            min-height: 0;
+            overflow: hidden;
+            background: var(--surface);
+        }
+
+        .session-sidebar {
+            border-right: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .session-sidebar header {
+            padding: 20px 24px 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .session-sidebar h1 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 600;
+        }
+
+        .session-sidebar p {
+            margin: 6px 0 0;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .session-controls {
+            padding: 0 16px 16px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .session-controls input[type="text"] {
+            padding: 10px 12px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 14px;
+            transition: var(--transition);
+        }
+
+        .session-controls input[type="text"]:focus {
+            outline: none;
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(30, 96, 225, 0.2);
+        }
+
+        .session-controls button {
+            padding: 10px 12px;
+            border: none;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 500;
+            background: var(--primary);
+            color: white;
+            cursor: pointer;
+            transition: var(--transition);
+        }
+
+        .session-controls button:hover {
+            background: var(--primary-dark);
+        }
+
+        .session-list {
+            flex: 1;
+            overflow-y: auto;
+            padding: 0 12px 12px;
+        }
+
+        .session-item {
+            border-radius: 12px;
+            padding: 14px 16px;
+            margin: 6px 0;
+            background: transparent;
+            border: 1px solid transparent;
+            cursor: pointer;
+            transition: var(--transition);
+        }
+
+        .session-item:hover {
+            background: #f8fafc;
+            border-color: var(--border);
+        }
+
+        .session-item.active {
+            background: rgba(30, 96, 225, 0.08);
+            border-color: rgba(30, 96, 225, 0.35);
+        }
+
+        .session-item .title {
+            font-size: 15px;
+            font-weight: 600;
+            margin-bottom: 6px;
+        }
+
+        .session-item .meta {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .session-item .status {
+            padding: 2px 8px;
+            border-radius: 999px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+
+        .session-item .status.open {
+            background: rgba(30, 96, 225, 0.12);
+            color: var(--primary-dark);
+        }
+
+        .session-item .status.resolved {
+            background: rgba(22, 163, 74, 0.12);
+            color: var(--success);
+        }
+
+        .chat-main {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        .chat-header {
+            padding: 20px 28px 18px;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .chat-header .info h2 {
+            margin: 0 0 4px;
+            font-size: 20px;
+            font-weight: 600;
+        }
+
+        .chat-header .info p {
+            margin: 0;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .chat-header .actions {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .chat-header button,
+        .chat-header select {
+            padding: 8px 12px;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            background: white;
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 13px;
+        }
+
+        .chat-header button.primary {
+            background: var(--primary);
+            border-color: var(--primary);
+            color: white;
+        }
+
+        .chat-header button.primary:hover {
+            background: var(--primary-dark);
+        }
+
+        .chat-log-wrapper {
+            flex: 1;
+            overflow-y: auto;
+            padding: 28px;
+            background: #f8fafc;
+        }
+
+        .chat-log {
+            max-width: 780px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .chat-message {
+            display: flex;
+            gap: 12px;
+            align-items: flex-start;
+        }
+
+        .chat-message.user {
+            flex-direction: row-reverse;
+        }
+
+        .chat-message .avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18px;
+            color: white;
+            flex-shrink: 0;
+        }
+
+        .chat-message.user .avatar {
+            background: var(--primary);
+        }
+
+        .chat-message.assistant .avatar {
+            background: #16a34a;
+        }
+
+        .chat-message.system .avatar {
+            background: #0f172a;
+        }
+
+        .chat-message .bubble {
+            max-width: 70%;
+            padding: 14px 18px;
+            border-radius: 16px;
+            box-shadow: var(--shadow-sm);
+            background: white;
+            font-size: 14px;
+            line-height: 1.6;
+            position: relative;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .chat-message.user .bubble {
+            background: var(--primary);
+            color: white;
+        }
+
+        .chat-message .meta {
+            margin-top: 8px;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .chat-message .sources {
+            margin-top: 12px;
+            padding-top: 12px;
+            border-top: 1px solid var(--border);
+        }
+
+        .chat-message .sources h4 {
+            margin: 0 0 6px;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+        }
+
+        .chat-message .sources ul {
+            margin: 0;
+            padding-left: 16px;
+            color: var(--text-secondary);
+            font-size: 12px;
+        }
+
+        .typing-indicator {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .typing-indicator span {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--text-secondary);
+            animation: blink 1s infinite ease-in-out;
+        }
+
+        .typing-indicator span:nth-child(2) {
+            animation-delay: 0.2s;
+        }
+
+        .typing-indicator span:nth-child(3) {
+            animation-delay: 0.4s;
+        }
+
+        @keyframes blink {
+            0%,
+            80%,
+            100% {
+                opacity: 0.2;
+                transform: translateY(0);
+            }
+
+            40% {
+                opacity: 1;
+                transform: translateY(-2px);
+            }
+        }
+
+        .composer {
+            padding: 22px 28px;
+            border-top: 1px solid var(--border);
+            background: white;
+        }
+
+        .composer-inner {
+            display: flex;
+            align-items: flex-end;
+            gap: 16px;
+        }
+
+        .composer textarea {
+            flex: 1;
+            min-height: 60px;
+            max-height: 200px;
+            padding: 12px 14px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            font-size: 14px;
+            resize: vertical;
+            transition: var(--transition);
+        }
+
+        .composer textarea:focus {
+            outline: none;
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(30, 96, 225, 0.2);
+        }
+
+        .composer button {
+            padding: 12px 20px;
+            border: none;
+            border-radius: 12px;
+            background: var(--primary);
+            color: white;
+            font-weight: 600;
+            font-size: 14px;
+            cursor: pointer;
+            transition: var(--transition);
+        }
+
+        .composer button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .composer button:not(:disabled):hover {
+            background: var(--primary-dark);
+        }
+
+        .context-panel {
+            border-left: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .context-panel header {
+            padding: 20px 24px 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .context-panel h3 {
+            margin: 0;
+            font-size: 17px;
+            font-weight: 600;
+        }
+
+        .context-panel .section {
+            padding: 16px 24px;
+            border-bottom: 1px solid var(--border);
+            flex: 1;
+            overflow-y: auto;
+        }
+
+        .context-panel .section:last-child {
+            border-bottom: none;
+        }
+
+        .context-panel .empty {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        .source-card {
+            background: rgba(15, 23, 42, 0.04);
+            border-radius: 12px;
+            padding: 12px 14px;
+            margin-bottom: 10px;
+        }
+
+        .source-card:last-child {
+            margin-bottom: 0;
+        }
+
+        .source-card .source-title {
+            font-size: 13px;
+            font-weight: 600;
+            margin-bottom: 6px;
+            color: var(--primary-dark);
+        }
+
+        .source-card .source-meta {
+            font-size: 12px;
+            color: var(--text-secondary);
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .source-card a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .source-card a:hover {
+            text-decoration: underline;
+        }
+
+        .session-meta {
+            font-size: 12px;
+            color: var(--text-secondary);
+            display: grid;
+            gap: 6px;
+        }
+
+        .toast-container {
+            position: fixed;
+            top: 24px;
+            right: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            z-index: 9999;
+        }
+
+        .toast {
+            min-width: 260px;
+            padding: 14px 18px;
+            border-radius: 12px;
+            color: white;
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            box-shadow: var(--shadow-sm);
+            opacity: 0;
+            transform: translateY(-10px);
+            animation: toast-in 0.2s forwards ease-out;
+        }
+
+        .toast.success {
+            background: var(--success);
+        }
+
+        .toast.error {
+            background: var(--danger);
+        }
+
+        .toast.info {
+            background: var(--primary);
+        }
+
+        @keyframes toast-in {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @media (max-width: 1280px) {
+            :root {
+                --context-width: 260px;
+            }
+
+            .chat-log {
+                max-width: 640px;
+            }
+        }
+
+        @media (max-width: 1024px) {
+            :root {
+                --sidebar-width: 280px;
+            }
+
+            .app-shell {
+                grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+            }
+
+            .context-panel {
+                display: none;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                background: white;
+            }
+
+            .app-shell {
+                display: flex;
+                flex-direction: column;
+            }
+
+            .session-sidebar {
+                position: sticky;
+                top: 0;
+                z-index: 100;
+            }
+
+            .chat-log-wrapper {
+                padding: 20px 16px;
+            }
+
+            .chat-message .bubble {
+                max-width: 85%;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-shell">
+        <aside class="session-sidebar">
+            <header>
+                <h1>대화 세션</h1>
+                <p>LangChain RAG 파이프라인과 연결된 상담 세션을 관리하세요.</p>
+            </header>
+            <div class="session-controls">
+                <input type="text" id="sessionSearch" placeholder="세션 검색" autocomplete="off">
+                <button id="newSessionButton"><i class="fa-solid fa-plus"></i>&nbsp; 새 채팅 시작</button>
+            </div>
+            <div class="session-list" id="sessionList">
+                <div class="empty">세션을 불러오는 중입니다...</div>
+            </div>
+        </aside>
+
+        <main class="chat-main">
+            <div class="chat-header">
+                <div class="info">
+                    <h2 id="chatTitle">세션을 선택하세요</h2>
+                    <p id="chatSubtitle">LangChain에 연결된 OpenAI 모델이 지식베이스 기반 답변을 제공합니다.</p>
+                </div>
+                <div class="actions">
+                    <button id="refreshButton" title="목록 새로고침"><i class="fa-solid fa-rotate"></i></button>
+                    <button id="endSessionButton" class="primary" disabled>세션 종료</button>
+                </div>
+            </div>
+
+            <div class="chat-log-wrapper">
+                <div class="chat-log" id="chatLog">
+                    <div class="empty" id="chatEmptyState">왼쪽에서 대화를 선택하거나 새 세션을 생성하세요.</div>
+                </div>
+            </div>
+
+            <form class="composer" id="messageForm">
+                <div class="composer-inner">
+                    <textarea id="messageInput" placeholder="질문을 입력하고 Enter로 전송하세요." disabled></textarea>
+                    <button type="submit" id="sendButton" disabled>
+                        <i class="fa-solid fa-paper-plane"></i>
+                    </button>
+                </div>
+            </form>
+        </main>
+
+        <aside class="context-panel">
+            <header>
+                <h3>지식베이스 컨텍스트</h3>
+            </header>
+            <div class="section" id="sourceSection">
+                <div class="empty">가장 최근 답변에서 활용한 문서가 여기에 표시됩니다.</div>
+            </div>
+            <div class="section">
+                <h4>세션 정보</h4>
+                <div class="session-meta" id="sessionMeta">
+                    <span>선택된 세션이 없습니다.</span>
+                </div>
+            </div>
+        </aside>
+    </div>
+
+    <div class="toast-container" id="toastContainer"></div>
+
+    <script>
+        const API_BASE_URL = localStorage.getItem('garam_api_base_url') || 'http://localhost:5000';
+        const SESSION_STORAGE_KEY = 'garampos_chat_selected_session';
+        const SEARCH_DEBOUNCE = 200;
+
+        const state = {
+            sessions: [],
+            filteredSessions: [],
+            messages: [],
+            currentSessionId: null,
+            typingTimer: null,
+            isSending: false,
+        };
+
+        const elements = {
+            sessionList: document.getElementById('sessionList'),
+            sessionSearch: document.getElementById('sessionSearch'),
+            newSessionButton: document.getElementById('newSessionButton'),
+            refreshButton: document.getElementById('refreshButton'),
+            endSessionButton: document.getElementById('endSessionButton'),
+            chatTitle: document.getElementById('chatTitle'),
+            chatSubtitle: document.getElementById('chatSubtitle'),
+            chatLog: document.getElementById('chatLog'),
+            chatEmptyState: document.getElementById('chatEmptyState'),
+            messageForm: document.getElementById('messageForm'),
+            messageInput: document.getElementById('messageInput'),
+            sendButton: document.getElementById('sendButton'),
+            sourceSection: document.getElementById('sourceSection'),
+            sessionMeta: document.getElementById('sessionMeta'),
+            toastContainer: document.getElementById('toastContainer'),
+        };
+
+        function formatDate(isoString) {
+            if (!isoString) return '-';
+            const date = new Date(isoString);
+            if (Number.isNaN(date.getTime())) return '-';
+            return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+        }
+
+        async function fetchJSON(url, options = {}) {
+            const opts = { ...options };
+            opts.headers = {
+                ...(options.headers || {}),
+            };
+            if (opts.body && typeof opts.body !== 'string') {
+                if (!opts.headers['Content-Type']) {
+                    opts.headers['Content-Type'] = 'application/json';
+                }
+                opts.body = JSON.stringify(opts.body);
+            }
+
+            try {
+                const response = await fetch(url, opts);
+                const text = await response.text();
+                if (!response.ok) {
+                    let message = `HTTP ${response.status}`;
+                    if (text) {
+                        try {
+                            const parsed = JSON.parse(text);
+                            if (parsed?.detail) {
+                                message = parsed.detail;
+                            } else if (parsed?.message) {
+                                message = parsed.message;
+                            }
+                        } catch (err) {
+                            message = text;
+                        }
+                    }
+                    const error = new Error(message);
+                    error.status = response.status;
+                    error.body = text;
+                    throw error;
+                }
+
+                if (!text) {
+                    return null;
+                }
+
+                try {
+                    return JSON.parse(text);
+                } catch (err) {
+                    return null;
+                }
+            } catch (error) {
+                if (error instanceof Error) {
+                    throw error;
+                }
+                const fallback = new Error('네트워크 오류가 발생했습니다.');
+                fallback.status = 0;
+                throw fallback;
+            }
+        }
+
+        function showToast(message, type = 'info') {
+            const toast = document.createElement('div');
+            toast.className = `toast ${type}`;
+            toast.innerHTML = `<i class="fa-solid ${type === 'success' ? 'fa-circle-check' : type === 'error' ? 'fa-circle-exclamation' : 'fa-circle-info'}"></i><span>${message}</span>`;
+            elements.toastContainer.appendChild(toast);
+            setTimeout(() => {
+                toast.style.opacity = '0';
+                toast.style.transform = 'translateY(-10px)';
+                setTimeout(() => toast.remove(), 200);
+            }, 3200);
+        }
+
+        function renderSessionList() {
+            const sessions = state.filteredSessions.length ? state.filteredSessions : state.sessions;
+            if (!sessions.length) {
+                elements.sessionList.innerHTML = '<div class="empty">생성된 세션이 없습니다. 새 채팅을 시작해보세요.</div>';
+                return;
+            }
+
+            const fragment = document.createDocumentFragment();
+            sessions.forEach((session) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'session-item' + (session.id === state.currentSessionId ? ' active' : '');
+
+                const title = document.createElement('div');
+                title.className = 'title';
+                title.textContent = session.title || '제목 없음';
+
+                const meta = document.createElement('div');
+                meta.className = 'meta';
+                const createdAt = document.createElement('span');
+                createdAt.textContent = formatDate(session.created_at);
+                const status = document.createElement('span');
+                status.className = 'status ' + (session.resolved ? 'resolved' : 'open');
+                status.textContent = session.resolved ? 'Resolved' : 'Open';
+
+                meta.appendChild(createdAt);
+                meta.appendChild(status);
+
+                button.appendChild(title);
+                button.appendChild(meta);
+                button.addEventListener('click', () => selectSession(session.id));
+                fragment.appendChild(button);
+            });
+            elements.sessionList.innerHTML = '';
+            elements.sessionList.appendChild(fragment);
+        }
+
+        function renderMessages() {
+            if (!state.messages.length) {
+                elements.chatLog.innerHTML = '<div class="empty">아직 메시지가 없습니다. 질문을 입력해보세요.</div>';
+                return;
+            }
+
+            const fragment = document.createDocumentFragment();
+            state.messages.forEach((msg) => {
+                const item = document.createElement('div');
+                item.className = `chat-message ${msg.role}`;
+
+                const avatar = document.createElement('div');
+                avatar.className = 'avatar';
+                const iconEl = document.createElement('i');
+                iconEl.className = 'fa-solid ' + (msg.role === 'assistant' ? 'fa-robot' : msg.role === 'user' ? 'fa-user' : 'fa-circle-info');
+                avatar.appendChild(iconEl);
+
+                const body = document.createElement('div');
+                const bubble = document.createElement('div');
+                bubble.className = 'bubble';
+                if (msg.isTyping) {
+                    bubble.innerHTML = '<div class="typing-indicator"><span></span><span></span><span></span></div>';
+                } else {
+                    bubble.textContent = msg.content || '';
+                }
+
+                const meta = document.createElement('div');
+                meta.className = 'meta';
+                const roleLabel = msg.role === 'assistant' ? 'Assistant' : msg.role === 'user' ? 'User' : 'System';
+                meta.textContent = `${roleLabel} · ${formatDate(msg.created_at)}`;
+
+                body.appendChild(bubble);
+                body.appendChild(meta);
+
+                item.appendChild(avatar);
+                item.appendChild(body);
+
+                if (!msg.isTyping && msg.role === 'assistant' && msg.extra_data?.sources?.length) {
+                    const sourcesDiv = document.createElement('div');
+                    sourcesDiv.className = 'sources';
+                    const heading = document.createElement('h4');
+                    heading.textContent = '참고 문서';
+                    const list = document.createElement('ul');
+                    msg.extra_data.sources.forEach((source) => {
+                        const itemEl = document.createElement('li');
+                        const title = source.title || source.document_title || '제목 없음';
+                        const scoreText = typeof source.score === 'number' ? ` (score: ${source.score.toFixed(3)})` : '';
+                        if (source.url) {
+                            const link = document.createElement('a');
+                            link.href = source.url;
+                            link.target = '_blank';
+                            link.rel = 'noopener noreferrer';
+                            link.textContent = title;
+                            itemEl.appendChild(link);
+                            if (scoreText) {
+                                itemEl.appendChild(document.createTextNode(scoreText));
+                            }
+                        } else {
+                            itemEl.textContent = `${title}${scoreText}`;
+                        }
+                        list.appendChild(itemEl);
+                    });
+                    sourcesDiv.appendChild(heading);
+                    sourcesDiv.appendChild(list);
+                    bubble.appendChild(sourcesDiv);
+                }
+
+                fragment.appendChild(item);
+            });
+
+            elements.chatLog.innerHTML = '';
+            elements.chatLog.appendChild(fragment);
+            const scrollContainer = elements.chatLog.parentElement;
+            if (scrollContainer) {
+                scrollContainer.scrollTop = scrollContainer.scrollHeight;
+            }
+        }
+
+        function renderSourcesFromMessage(message) {
+            if (!message || !message.extra_data?.sources?.length) {
+                elements.sourceSection.innerHTML = '<div class="empty">참고한 문서 정보가 없습니다.</div>';
+                return;
+            }
+
+            const fragment = document.createDocumentFragment();
+            message.extra_data.sources.forEach((source, index) => {
+                const card = document.createElement('div');
+                card.className = 'source-card';
+
+                const titleEl = document.createElement('div');
+                titleEl.className = 'source-title';
+                titleEl.textContent = source.title || source.document_title || `자료 ${index + 1}`;
+
+                const meta = document.createElement('div');
+                meta.className = 'source-meta';
+                if (source.chunk_preview) {
+                    const preview = document.createElement('span');
+                    preview.textContent = source.chunk_preview;
+                    meta.appendChild(preview);
+                }
+                if (typeof source.score === 'number') {
+                    const score = document.createElement('span');
+                    score.textContent = `관련도: ${source.score.toFixed(3)}`;
+                    meta.appendChild(score);
+                }
+                if (source.url) {
+                    const link = document.createElement('a');
+                    link.href = source.url;
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    link.textContent = '원문 보기';
+                    meta.appendChild(link);
+                }
+
+                card.appendChild(titleEl);
+                card.appendChild(meta);
+                fragment.appendChild(card);
+            });
+            elements.sourceSection.innerHTML = '';
+            elements.sourceSection.appendChild(fragment);
+        }
+
+        function renderSessionMeta(session) {
+            if (!session) {
+                elements.sessionMeta.innerHTML = '<span>선택된 세션이 없습니다.</span>';
+                return;
+            }
+
+            elements.sessionMeta.innerHTML = '';
+            const fragment = document.createDocumentFragment();
+
+            const fields = [
+                ['세션 ID', session.id],
+                ['생성일', formatDate(session.created_at)],
+                ['종료일', session.ended_at ? formatDate(session.ended_at) : '-'],
+                ['상태', session.resolved ? 'Resolved' : 'Open'],
+            ];
+
+            fields.forEach(([label, value]) => {
+                const row = document.createElement('span');
+                const strong = document.createElement('strong');
+                strong.textContent = `${label}:`;
+                row.appendChild(strong);
+                row.appendChild(document.createTextNode(` ${value}`));
+                fragment.appendChild(row);
+            });
+
+            if (session.preview) {
+                const previewRow = document.createElement('span');
+                const strong = document.createElement('strong');
+                strong.textContent = '미리보기:';
+                previewRow.appendChild(strong);
+                previewRow.appendChild(document.createTextNode(` ${session.preview}`));
+                fragment.appendChild(previewRow);
+            }
+
+            elements.sessionMeta.appendChild(fragment);
+        }
+
+        function applySearchFilter(keyword) {
+            const normalized = keyword.trim().toLowerCase();
+            if (!normalized) {
+                state.filteredSessions = [];
+                renderSessionList();
+                return;
+            }
+
+            state.filteredSessions = state.sessions.filter((session) => {
+                const title = session.title?.toLowerCase() || '';
+                return title.includes(normalized) || String(session.id).includes(normalized);
+            });
+            renderSessionList();
+        }
+
+        let searchTimer = null;
+        elements.sessionSearch.addEventListener('input', (event) => {
+            const value = event.target.value;
+            if (searchTimer) {
+                clearTimeout(searchTimer);
+            }
+            searchTimer = setTimeout(() => applySearchFilter(value), SEARCH_DEBOUNCE);
+        });
+
+        elements.newSessionButton.addEventListener('click', async () => {
+            const title = prompt('새 세션 제목을 입력하세요.', '새 상담 세션');
+            if (title === null) {
+                return;
+            }
+            const payload = {
+                title: title.trim() || '새 상담 세션',
+                preview: '',
+                resolved: false,
+            };
+            try {
+                const session = await fetchJSON(`${API_BASE_URL}/chat/sessions`, {
+                    method: 'POST',
+                    body: payload,
+                });
+                showToast('새 세션이 생성되었습니다.', 'success');
+                await loadSessions(session.id);
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '세션 생성 중 오류가 발생했습니다.', 'error');
+            }
+        });
+
+        elements.refreshButton.addEventListener('click', () => loadSessions(state.currentSessionId));
+
+        elements.endSessionButton.addEventListener('click', async () => {
+            if (!state.currentSessionId) return;
+            const confirmed = confirm('현재 세션을 종료하고 해결됨 상태로 표시할까요?');
+            if (!confirmed) return;
+            try {
+                await fetchJSON(`${API_BASE_URL}/chat/sessions/${state.currentSessionId}/end`, {
+                    method: 'POST',
+                    body: { resolved: true },
+                });
+                showToast('세션이 종료되었습니다.', 'success');
+                await loadSessions(state.currentSessionId);
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '세션 종료에 실패했습니다.', 'error');
+            }
+        });
+
+        elements.messageForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const question = elements.messageInput.value.trim();
+            if (!question || !state.currentSessionId || state.isSending) {
+                return;
+            }
+
+            state.isSending = true;
+            elements.sendButton.disabled = true;
+            elements.messageInput.value = '';
+            elements.messageInput.disabled = true;
+
+            const nowISO = new Date().toISOString();
+            const userMessage = {
+                id: `local-${Date.now()}`,
+                role: 'user',
+                content: question,
+                created_at: nowISO,
+            };
+            state.messages.push(userMessage);
+            renderMessages();
+
+            try {
+                await fetchJSON(`${API_BASE_URL}/chat/sessions/${state.currentSessionId}/messages`, {
+                    method: 'POST',
+                    body: {
+                        session_id: state.currentSessionId,
+                        role: 'user',
+                        content: question,
+                    },
+                });
+            } catch (error) {
+                console.warn('사용자 메시지 저장 실패:', error);
+            }
+
+            const typingMessage = {
+                id: 'typing-indicator',
+                role: 'assistant',
+                content: '',
+                created_at: new Date().toISOString(),
+                isTyping: true,
+            };
+            state.messages.push(typingMessage);
+            renderMessages();
+
+            try {
+                const ragResult = await askLLM(question);
+                removeTypingIndicator();
+
+                const answerText = ragResult?.answer || '죄송합니다. 현재 답변을 가져오지 못했습니다.';
+                const assistantMessage = {
+                    id: ragResult?.message_id || `local-assistant-${Date.now()}`,
+                    role: 'assistant',
+                    content: answerText,
+                    created_at: new Date().toISOString(),
+                    extra_data: { sources: ragResult?.sources || ragResult?.documents || [] },
+                };
+
+                state.messages.push(assistantMessage);
+                renderMessages();
+                renderSourcesFromMessage(assistantMessage);
+
+                try {
+                    await fetchJSON(`${API_BASE_URL}/chat/sessions/${state.currentSessionId}/messages`, {
+                        method: 'POST',
+                        body: {
+                            session_id: state.currentSessionId,
+                            role: 'assistant',
+                            content: answerText,
+                            extra_data: assistantMessage.extra_data,
+                        },
+                    });
+                } catch (error) {
+                    console.warn('assistant 메시지 저장 실패:', error);
+                }
+            } catch (error) {
+                console.error(error);
+                removeTypingIndicator();
+                const failureMessage = {
+                    id: `error-${Date.now()}`,
+                    role: 'assistant',
+                    content: '죄송합니다. LLM 응답을 가져오는 중 오류가 발생했습니다.',
+                    created_at: new Date().toISOString(),
+                };
+                state.messages.push(failureMessage);
+                renderMessages();
+                showToast(error.message || 'LLM 응답 요청에 실패했습니다.', 'error');
+            } finally {
+                state.isSending = false;
+                const session = state.sessions.find((s) => s.id === state.currentSessionId);
+                if (session?.resolved) {
+                    elements.messageInput.disabled = true;
+                    elements.sendButton.disabled = true;
+                } else {
+                    elements.messageInput.disabled = false;
+                    elements.sendButton.disabled = false;
+                    elements.messageInput.focus();
+                }
+            }
+        });
+
+        elements.messageInput.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                elements.messageForm.dispatchEvent(new Event('submit', { cancelable: true }));
+            }
+        });
+
+        async function askLLM(question) {
+            const sessionId = state.currentSessionId;
+            const candidates = [
+                `${API_BASE_URL}/chat/sessions/${sessionId}/qa`,
+                `${API_BASE_URL}/qa/query`,
+                `${API_BASE_URL}/qa`,
+            ];
+            let lastError = null;
+            for (const endpoint of candidates) {
+                try {
+                    const result = await fetchJSON(endpoint, {
+                        method: 'POST',
+                        body: {
+                            session_id: sessionId,
+                            question,
+                        },
+                    });
+                    if (result) {
+                        return result;
+                    }
+                } catch (error) {
+                    lastError = error;
+                    if (error.status && error.status !== 404 && error.status !== 405 && error.status !== 500) {
+                        break;
+                    }
+                }
+            }
+            throw lastError || new Error('LLM 응답을 받을 수 없습니다.');
+        }
+
+        function removeTypingIndicator() {
+            const idx = state.messages.findIndex((msg) => msg.isTyping);
+            if (idx >= 0) {
+                state.messages.splice(idx, 1);
+                renderMessages();
+            }
+        }
+
+        async function selectSession(sessionId) {
+            if (!sessionId) return;
+            if (sessionId === state.currentSessionId) return;
+
+            state.currentSessionId = sessionId;
+            localStorage.setItem(SESSION_STORAGE_KEY, String(sessionId));
+            const session = state.sessions.find((s) => s.id === sessionId);
+            elements.chatTitle.textContent = session?.title || `세션 ${sessionId}`;
+            elements.chatSubtitle.textContent = session?.resolved
+                ? '종료된 세션입니다. 추가 질문을 하려면 새 채팅을 생성하세요.'
+                : '지식베이스 기반 답변을 얻으려면 질문을 입력하세요.';
+            elements.endSessionButton.disabled = !!session?.resolved;
+            elements.messageInput.disabled = !!session?.resolved;
+            elements.sendButton.disabled = !!session?.resolved;
+            renderSessionMeta(session);
+            renderSessionList();
+
+            await loadMessages(sessionId);
+        }
+
+        async function loadSessions(selectSessionId = null) {
+            try {
+                const sessions = await fetchJSON(`${API_BASE_URL}/chat/sessions?limit=50`);
+                state.sessions = Array.isArray(sessions) ? sessions : [];
+                state.sessions.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+                state.filteredSessions = [];
+                renderSessionList();
+
+                const targetSessionId = selectSessionId || Number(localStorage.getItem(SESSION_STORAGE_KEY));
+                if (targetSessionId && state.sessions.some((s) => s.id === Number(targetSessionId))) {
+                    await selectSession(Number(targetSessionId));
+                } else if (state.sessions.length) {
+                    await selectSession(state.sessions[0].id);
+                } else {
+                    state.currentSessionId = null;
+                    elements.chatTitle.textContent = '세션을 선택하세요';
+                    elements.chatSubtitle.textContent = 'LangChain에 연결된 OpenAI 모델이 지식베이스 기반 답변을 제공합니다.';
+                    elements.messageInput.disabled = true;
+                    elements.sendButton.disabled = true;
+                    elements.endSessionButton.disabled = true;
+                    elements.chatLog.innerHTML = '<div class="empty">새 세션을 생성하면 대화를 시작할 수 있습니다.</div>';
+                    renderSessionMeta(null);
+                    renderSourcesFromMessage(null);
+                }
+            } catch (error) {
+                console.error(error);
+                showToast(error.message || '세션 목록을 가져오지 못했습니다.', 'error');
+            }
+        }
+
+        async function loadMessages(sessionId) {
+            if (!sessionId) return;
+            try {
+                const messages = await fetchJSON(`${API_BASE_URL}/chat/sessions/${sessionId}/messages`);
+                state.messages = Array.isArray(messages) ? messages : [];
+                renderMessages();
+                const lastAssistant = [...state.messages].reverse().find((msg) => msg.role === 'assistant');
+                renderSourcesFromMessage(lastAssistant || null);
+                const session = state.sessions.find((s) => s.id === sessionId);
+                if (session?.resolved) {
+                    elements.messageInput.disabled = true;
+                    elements.sendButton.disabled = true;
+                } else {
+                    elements.messageInput.disabled = false;
+                    elements.sendButton.disabled = false;
+                    elements.messageInput.focus();
+                }
+            } catch (error) {
+                console.error(error);
+                state.messages = [];
+                renderMessages();
+                renderSourcesFromMessage(null);
+                showToast(error.message || '메시지를 불러오지 못했습니다.', 'error');
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            loadSessions();
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `chat_session.html` screen that lists chat sessions and renders live conversations
- wire message sending to the chat APIs while calling the LangChain RAG endpoint with graceful fallbacks and error toasts
- surface retrieved source documents and session metadata alongside the conversation with responsive styling

## Testing
- not run (static HTML only)

------
https://chatgpt.com/codex/tasks/task_e_68dc8676f3448328935d0e612c5bf0db