### PR TITLE
Add LLM connectivity status management to chat session UI

### DIFF
--- a/html/chat_session.html
+++ b/html/chat_session.html
@@ -97,6 +97,105 @@
             transition: var(--transition);
         }
 
+        .api-status-card {
+            padding: 14px 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: rgba(15, 23, 42, 0.03);
+            display: grid;
+            gap: 12px;
+            transition: var(--transition);
+        }
+
+        .api-status-card .api-status-header {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .api-status-card .status-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--border);
+            box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.2);
+        }
+
+        .api-status-card .status-text {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .api-status-card .status-title {
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+
+        .api-status-card .status-message {
+            font-size: 13px;
+            color: var(--text-primary);
+        }
+
+        .api-status-card .api-status-url {
+            font-size: 12px;
+            color: var(--text-secondary);
+            word-break: break-all;
+        }
+
+        .api-status-card .api-status-actions {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+        }
+
+        .api-status-card .status-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 8px 10px;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            background: white;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-primary);
+            cursor: pointer;
+            transition: var(--transition);
+        }
+
+        .api-status-card .status-button:hover {
+            border-color: var(--primary);
+            color: var(--primary);
+        }
+
+        .api-status-card.connected {
+            border-color: rgba(22, 163, 74, 0.4);
+            background: rgba(22, 163, 74, 0.08);
+        }
+
+        .api-status-card.connected .status-dot {
+            background: var(--success);
+            box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.2);
+        }
+
+        .api-status-card.disconnected {
+            border-color: rgba(220, 38, 38, 0.35);
+            background: rgba(220, 38, 38, 0.08);
+        }
+
+        .api-status-card.disconnected .status-dot {
+            background: var(--danger);
+            box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.15);
+        }
+
+        .api-status-card.checking .status-dot {
+            background: var(--text-secondary);
+            animation: pulse 1.4s infinite ease-in-out;
+        }
+
         .session-controls input[type="text"]:focus {
             outline: none;
             border-color: var(--primary);
@@ -533,6 +632,19 @@
             }
         }
 
+        @keyframes pulse {
+            0%,
+            100% {
+                opacity: 0.4;
+                transform: scale(1);
+            }
+
+            50% {
+                opacity: 1;
+                transform: scale(1.2);
+            }
+        }
+
         @media (max-width: 1280px) {
             :root {
                 --context-width: 260px;
@@ -594,6 +706,26 @@
             <div class="session-controls">
                 <input type="text" id="sessionSearch" placeholder="세션 검색" autocomplete="off">
                 <button id="newSessionButton"><i class="fa-solid fa-plus"></i>&nbsp; 새 채팅 시작</button>
+                <div class="api-status-card checking" id="apiStatusCard" aria-live="polite">
+                    <div class="api-status-header">
+                        <span class="status-dot" id="apiStatusDot" aria-hidden="true"></span>
+                        <div class="status-text">
+                            <div class="status-title">LLM 연결 상태</div>
+                            <div class="status-message" id="apiStatusMessage">연결 확인 중...</div>
+                        </div>
+                    </div>
+                    <div class="api-status-url" id="apiBaseUrlLabel"></div>
+                    <div class="api-status-actions">
+                        <button type="button" class="status-button" id="checkApiButton">
+                            <i class="fa-solid fa-plug-circle-check"></i>
+                            연결 확인
+                        </button>
+                        <button type="button" class="status-button" id="editApiButton">
+                            <i class="fa-solid fa-gear"></i>
+                            주소 설정
+                        </button>
+                    </div>
+                </div>
             </div>
             <div class="session-list" id="sessionList">
                 <div class="empty">세션을 불러오는 중입니다...</div>
@@ -647,9 +779,12 @@
     <div class="toast-container" id="toastContainer"></div>
 
     <script>
-        const API_BASE_URL = localStorage.getItem('garam_api_base_url') || 'http://localhost:5000';
+        const API_STORAGE_KEY = 'garam_api_base_url';
         const SESSION_STORAGE_KEY = 'garampos_chat_selected_session';
         const SEARCH_DEBOUNCE = 200;
+        const DEFAULT_API_BASE_URL = 'http://localhost:5000';
+
+        let API_BASE_URL = localStorage.getItem(API_STORAGE_KEY) || DEFAULT_API_BASE_URL;
 
         const state = {
             sessions: [],
@@ -658,6 +793,8 @@
             currentSessionId: null,
             typingTimer: null,
             isSending: false,
+            isApiConnected: false,
+            isCheckingApi: false,
         };
 
         const elements = {
@@ -676,7 +813,94 @@
             sourceSection: document.getElementById('sourceSection'),
             sessionMeta: document.getElementById('sessionMeta'),
             toastContainer: document.getElementById('toastContainer'),
+            apiStatusCard: document.getElementById('apiStatusCard'),
+            apiStatusMessage: document.getElementById('apiStatusMessage'),
+            apiBaseUrlLabel: document.getElementById('apiBaseUrlLabel'),
+            checkApiButton: document.getElementById('checkApiButton'),
+            editApiButton: document.getElementById('editApiButton'),
         };
+
+        function normalizeApiBaseUrl(value) {
+            const raw = (value || '').trim();
+            if (!raw) {
+                throw new Error('API 기본 주소를 입력해주세요.');
+            }
+            let candidate = raw;
+            if (!/^https?:\/\//i.test(candidate)) {
+                candidate = `http://${candidate}`;
+            }
+            const url = new URL(candidate);
+            const pathname = url.pathname.replace(/\/+$/, '');
+            const normalizedPath = pathname === '/' ? '' : pathname;
+            return `${url.origin}${normalizedPath}`;
+        }
+
+        function setApiBaseUrl(newUrl, options = {}) {
+            const { persist = true } = options;
+            const normalized = normalizeApiBaseUrl(newUrl);
+            API_BASE_URL = normalized;
+            if (persist) {
+                localStorage.setItem(API_STORAGE_KEY, normalized);
+            }
+            updateApiBaseUrlLabel();
+            return normalized;
+        }
+
+        function updateApiBaseUrlLabel() {
+            if (elements.apiBaseUrlLabel) {
+                elements.apiBaseUrlLabel.textContent = `엔드포인트: ${API_BASE_URL}`;
+            }
+        }
+
+        function updateApiStatus(status, message) {
+            if (!elements.apiStatusCard) {
+                return;
+            }
+            elements.apiStatusCard.classList.remove('connected', 'disconnected', 'checking');
+            elements.apiStatusCard.classList.add(status);
+            elements.apiStatusCard.setAttribute('data-status', status);
+            elements.apiStatusCard.setAttribute('aria-label', `LLM 연결 상태: ${message}`);
+            if (elements.apiStatusMessage) {
+                elements.apiStatusMessage.textContent = message;
+            }
+        }
+
+        function getCurrentSession() {
+            if (!state.currentSessionId) {
+                return null;
+            }
+            return state.sessions.find((session) => session.id === state.currentSessionId) || null;
+        }
+
+        function shouldDisableComposer(session) {
+            if (state.isSending) {
+                return true;
+            }
+            if (!state.isApiConnected) {
+                return true;
+            }
+            if (!session) {
+                return true;
+            }
+            return !!session.resolved;
+        }
+
+        function applyComposerState(session) {
+            const targetSession = session || getCurrentSession();
+            const disabled = shouldDisableComposer(targetSession);
+            if (elements.messageInput) {
+                elements.messageInput.disabled = disabled;
+            }
+            if (elements.sendButton) {
+                elements.sendButton.disabled = disabled;
+            }
+            if (!disabled && elements.messageInput) {
+                elements.messageInput.focus();
+            }
+        }
+
+        updateApiBaseUrlLabel();
+        updateApiStatus('checking', '연결 확인 중...');
 
         function formatDate(isoString) {
             if (!isoString) return '-';
@@ -736,6 +960,48 @@
                 const fallback = new Error('네트워크 오류가 발생했습니다.');
                 fallback.status = 0;
                 throw fallback;
+            }
+        }
+
+        async function checkLLMConnection(options = {}) {
+            const { showSuccessToast = false, suppressErrorToast = false } = options;
+            if (state.isCheckingApi) {
+                return state.isApiConnected;
+            }
+
+            state.isCheckingApi = true;
+            updateApiStatus('checking', '연결 확인 중...');
+            try {
+                const model = await fetchJSON(`${API_BASE_URL}/models/active`);
+                if (!model) {
+                    throw new Error('활성화된 모델 정보를 가져오지 못했습니다.');
+                }
+                state.isApiConnected = true;
+                const provider = model.provider_name || 'LLM';
+                const modelName = model.name || '활성 모델';
+                const statusSuffix = model.status_text ? ` · ${model.status_text}` : '';
+                updateApiStatus('connected', `${provider} · ${modelName}${statusSuffix}`);
+                if (showSuccessToast) {
+                    showToast('LLM 연결이 확인되었습니다.', 'success');
+                }
+                applyComposerState(getCurrentSession());
+                return true;
+            } catch (error) {
+                state.isApiConnected = false;
+                let message = error instanceof Error ? error.message : 'LLM 연결을 확인할 수 없습니다.';
+                if (/active model/i.test(message)) {
+                    message = '활성화된 LLM 모델이 설정되어 있지 않습니다.';
+                } else if (/HTTP\s*404/i.test(message)) {
+                    message = 'LLM 엔드포인트를 찾을 수 없습니다.';
+                }
+                updateApiStatus('disconnected', message);
+                applyComposerState(null);
+                if (!suppressErrorToast) {
+                    showToast(message, 'error');
+                }
+                return false;
+            } finally {
+                state.isCheckingApi = false;
             }
         }
 
@@ -971,6 +1237,57 @@
             searchTimer = setTimeout(() => applySearchFilter(value), SEARCH_DEBOUNCE);
         });
 
+        if (elements.checkApiButton) {
+            elements.checkApiButton.addEventListener('click', () => {
+                checkLLMConnection({ showSuccessToast: true });
+            });
+        }
+
+        if (elements.editApiButton) {
+            elements.editApiButton.addEventListener('click', async () => {
+                const current = API_BASE_URL;
+                const input = prompt('LLM API 기본 주소를 입력하세요.', current);
+                if (input === null) {
+                    return;
+                }
+                try {
+                    const previousBaseUrl = API_BASE_URL;
+                    const normalized = setApiBaseUrl(input);
+                    if (normalized === previousBaseUrl) {
+                        showToast('입력한 주소가 현재와 동일합니다. 연결 상태를 다시 확인합니다.', 'info');
+                        const rechecked = await checkLLMConnection({ showSuccessToast: true });
+                        if (rechecked) {
+                            await loadSessions(state.currentSessionId);
+                        }
+                        return;
+                    }
+                    state.isApiConnected = false;
+                    applyComposerState(null);
+                    state.currentSessionId = null;
+                    state.sessions = [];
+                    state.filteredSessions = [];
+                    state.messages = [];
+                    renderSessionList();
+                    elements.chatLog.innerHTML = '<div class="empty">새 API 주소에 연결 중입니다. 연결을 확인하세요.</div>';
+                    renderSessionMeta(null);
+                    renderSourcesFromMessage(null);
+                    elements.chatTitle.textContent = '세션을 선택하세요';
+                    elements.chatSubtitle.textContent = 'LLM 연결을 확인하면 대화를 시작할 수 있습니다.';
+                    if (elements.messageInput) {
+                        elements.messageInput.value = '';
+                    }
+                    showToast('API 기본 주소가 저장되었습니다.', 'success');
+                    const connected = await checkLLMConnection({ showSuccessToast: true });
+                    if (connected) {
+                        await loadSessions(state.currentSessionId);
+                    }
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : '유효한 주소를 입력해주세요.';
+                    showToast(message, 'error');
+                }
+            });
+        }
+
         elements.newSessionButton.addEventListener('click', async () => {
             const title = prompt('새 세션 제목을 입력하세요.', '새 상담 세션');
             if (title === null) {
@@ -1016,7 +1333,7 @@
         elements.messageForm.addEventListener('submit', async (event) => {
             event.preventDefault();
             const question = elements.messageInput.value.trim();
-            if (!question || !state.currentSessionId || state.isSending) {
+            if (!question || !state.currentSessionId || state.isSending || !state.isApiConnected) {
                 return;
             }
 
@@ -1102,15 +1419,7 @@
                 showToast(error.message || 'LLM 응답 요청에 실패했습니다.', 'error');
             } finally {
                 state.isSending = false;
-                const session = state.sessions.find((s) => s.id === state.currentSessionId);
-                if (session?.resolved) {
-                    elements.messageInput.disabled = true;
-                    elements.sendButton.disabled = true;
-                } else {
-                    elements.messageInput.disabled = false;
-                    elements.sendButton.disabled = false;
-                    elements.messageInput.focus();
-                }
+                applyComposerState();
             }
         });
 
@@ -1171,12 +1480,18 @@
                 ? '종료된 세션입니다. 추가 질문을 하려면 새 채팅을 생성하세요.'
                 : '지식베이스 기반 답변을 얻으려면 질문을 입력하세요.';
             elements.endSessionButton.disabled = !!session?.resolved;
-            elements.messageInput.disabled = !!session?.resolved;
-            elements.sendButton.disabled = !!session?.resolved;
             renderSessionMeta(session);
             renderSessionList();
 
+            if (elements.messageInput) {
+                elements.messageInput.disabled = true;
+            }
+            if (elements.sendButton) {
+                elements.sendButton.disabled = true;
+            }
+
             await loadMessages(sessionId);
+            applyComposerState(session);
         }
 
         async function loadSessions(selectSessionId = null) {
@@ -1196,8 +1511,7 @@
                     state.currentSessionId = null;
                     elements.chatTitle.textContent = '세션을 선택하세요';
                     elements.chatSubtitle.textContent = 'LangChain에 연결된 OpenAI 모델이 지식베이스 기반 답변을 제공합니다.';
-                    elements.messageInput.disabled = true;
-                    elements.sendButton.disabled = true;
+                    applyComposerState(null);
                     elements.endSessionButton.disabled = true;
                     elements.chatLog.innerHTML = '<div class="empty">새 세션을 생성하면 대화를 시작할 수 있습니다.</div>';
                     renderSessionMeta(null);
@@ -1205,6 +1519,7 @@
                 }
             } catch (error) {
                 console.error(error);
+                applyComposerState(null);
                 showToast(error.message || '세션 목록을 가져오지 못했습니다.', 'error');
             }
         }
@@ -1218,25 +1533,36 @@
                 const lastAssistant = [...state.messages].reverse().find((msg) => msg.role === 'assistant');
                 renderSourcesFromMessage(lastAssistant || null);
                 const session = state.sessions.find((s) => s.id === sessionId);
-                if (session?.resolved) {
-                    elements.messageInput.disabled = true;
-                    elements.sendButton.disabled = true;
-                } else {
-                    elements.messageInput.disabled = false;
-                    elements.sendButton.disabled = false;
-                    elements.messageInput.focus();
-                }
+                applyComposerState(session);
             } catch (error) {
                 console.error(error);
                 state.messages = [];
                 renderMessages();
                 renderSourcesFromMessage(null);
+                applyComposerState(null);
                 showToast(error.message || '메시지를 불러오지 못했습니다.', 'error');
             }
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
-            loadSessions();
+        document.addEventListener('DOMContentLoaded', async () => {
+            try {
+                setApiBaseUrl(API_BASE_URL);
+            } catch (error) {
+                console.warn('API 기본 주소 초기화 실패:', error);
+                try {
+                    setApiBaseUrl(DEFAULT_API_BASE_URL);
+                } catch (innerError) {
+                    console.warn('기본 API 주소 설정에도 실패했습니다.', innerError);
+                }
+            }
+
+            try {
+                await checkLLMConnection({ suppressErrorToast: true });
+            } catch (error) {
+                console.error('LLM 연결 확인 중 오류:', error);
+            }
+
+            await loadSessions();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a connection status card and controls in the chat session sidebar so operators can view status and adjust the LLM API endpoint
- implement client-side logic to normalize and persist the API base URL, ping `/models/active`, and gate composer access on LLM availability
- refresh session and message workflows to respect connectivity changes and surface friendly feedback when the endpoint is unreachable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcadba175c8328a74a15f23f75a056