### PR TITLE
Ensure knowledge bulk page creation uses path knowledge ID

### DIFF
--- a/app/endpoints/knowledge.py
+++ b/app/endpoints/knowledge.py
@@ -121,9 +121,9 @@ class PagesBulkCreateIn(BaseModel):
 def bulk_create_pages(knowledge_id: int, payload: PagesBulkCreateIn, db: Session = Depends(get_db)):
     if not crud.get_knowledge(db, knowledge_id):
         raise HTTPException(status_code=404, detail="knowledge not found")
-    # 안전을 위해 knowledge_id 강제 주입
-    items = [{**p.model_dump(), "knowledge_id": knowledge_id} for p in payload.pages]
-    return crud.bulk_create_pages(db, items)
+    # 요청 본문에 포함된 knowledge_id는 무시하고 path parameter의 값을 사용
+    items = [p.model_dump(exclude={"knowledge_id"}) for p in payload.pages]
+    return crud.bulk_create_pages(db, knowledge_id, items)
 
 
 # ---------- KnowledgeChunk ----------

--- a/crud/knowledge.py
+++ b/crud/knowledge.py
@@ -108,7 +108,8 @@ def upsert_page(
     return obj
 
 
-def bulk_create_pages(db, knowledge_id: int, pages: list[dict]) -> int:
+def bulk_create_pages(db: Session, knowledge_id: int, pages: list[dict]) -> int:
+    """지식 페이지 일괄 생성 시 path의 knowledge_id를 강제 주입"""
     objs = [
         KnowledgePage(
             knowledge_id=knowledge_id,


### PR DESCRIPTION
## Summary
- update the knowledge bulk page endpoint to pass the knowledge id when calling the CRUD helper
- sanitize bulk page payloads so knowledge_id from the request body is ignored
- document the CRUD helper to clarify that knowledge_id is injected from the path parameter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcc03f950c832882e746f2a20a94d1