### PR TITLE
Provide SQLite fallback when DB configuration is missing

### DIFF
--- a/database/base.py
+++ b/database/base.py
@@ -1,6 +1,11 @@
+from pathlib import Path
 from sqlalchemy.ext.declarative import declarative_base
 import core.config as config
+import logging
 import os
+
+
+logger = logging.getLogger(__name__)
 
 Base = declarative_base()
 
@@ -10,5 +15,33 @@ pw = config.DB_PASSWORD
 server = config.DB_SERVER
 port = config.DB_PORT
 name = config.DB_NAME
-DATABASE_URL = os.getenv('DATABASE_URL', f'{database}://{user}:{pw}@{server}:{port}/{name}')
+
+
+def _build_sqlite_url() -> str:
+    default_path = Path(
+        os.getenv(
+            "SQLITE_DB_PATH",
+            Path(__file__).resolve().parent.parent / "garam.sqlite3",
+        )
+    )
+    default_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.warning(
+        "데이터베이스 환경 변수를 찾을 수 없어 SQLite 파일(%s)을 사용합니다.",
+        default_path,
+    )
+    return f"sqlite:///{default_path}"
+
+
+def _build_database_url() -> str:
+    explicit_url = os.getenv("DATABASE_URL")
+    if explicit_url:
+        return explicit_url
+
+    if all([database, user, pw, server, port, name]):
+        return f"{database}://{user}:{pw}@{server}:{port}/{name}"
+
+    return _build_sqlite_url()
+
+
+DATABASE_URL = _build_database_url()
 

--- a/database/session.py
+++ b/database/session.py
@@ -1,9 +1,18 @@
 from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import sessionmaker
 import database.base as base
 import psycopg2
+import sqlite3
 
-engine = create_engine(base.DATABASE_URL, echo=True)
+database_url = base.DATABASE_URL
+
+engine_kwargs = {"echo": True}
+
+if database_url.startswith("sqlite"):
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(database_url, **engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def get_db():
@@ -14,10 +23,15 @@ def get_db():
         db.close()
 
 def get_db_connection():
+    url = make_url(database_url)
+
+    if url.drivername.startswith("sqlite"):
+        return sqlite3.connect(url.database)
+
     return psycopg2.connect(
-        host=base.server,
-        dbname=base.name,
-        user=base.user,
-        password=base.pw,
-        port=base.port,
+        host=url.host,
+        dbname=url.database,
+        user=url.username,
+        password=url.password,
+        port=url.port,
     )


### PR DESCRIPTION
## Summary
- add logic to fall back to a local SQLite database when mandatory PostgreSQL environment variables are absent
- update the database session factory to work with the new SQLite fallback while keeping PostgreSQL support

## Testing
- python -m compileall database

------
https://chatgpt.com/codex/tasks/task_e_68dcc6ff8f4c8328a6e6e6694e69659f