### PR TITLE
Restrict LLM selection to OpenAI models

### DIFF
--- a/langchain_service/chain/qa_chain.py
+++ b/langchain_service/chain/qa_chain.py
@@ -5,7 +5,8 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from crud import model as crud_model
 from crud.knowledge import search_chunks_by_vector      # vector search 하는 곳
-from langchain_service.prompt.style import build_system_prompt, llm_params
+from langchain_service.prompt.style import build_system_prompt
+from langchain_service.llm.setup import llm_kwargs_for_model
 
 
 def make_qa_chain(db, get_llm, text_to_vector, *, knowledge_id=None, top_k=5):
@@ -38,7 +39,13 @@ def make_qa_chain(db, get_llm, text_to_vector, *, knowledge_id=None, top_k=5):
         ("human", "{question}")
     ])
 
-    llm = get_llm(**llm_params(m.fast_response_mode))
+    llm = get_llm(
+        **llm_kwargs_for_model(
+            fast_response_mode=m.fast_response_mode,
+            model_name=m.name,
+            provider_name=m.provider_name,
+        )
+    )
 
     return (
         RunnableMap({

--- a/langchain_service/llm/setup.py
+++ b/langchain_service/llm/setup.py
@@ -1,56 +1,84 @@
-from langchain_google_genai import ChatGoogleGenerativeAI
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Iterable, Optional
+
 from langchain_openai import ChatOpenAI
-from langchain_anthropic import ChatAnthropic
-from core.tools import fit_anthropic_model
+
 import core.config as config
-from pydantic import SecretStr
-from openai import OpenAI
-import os
-
-# 테스트용 openai 와 실제 서비스는 Exaone 이용
-def get_llm(provider="openai", model = None, api_key : str = None, temperature = 0.7):
-    if provider == "openai":
-        model_name = model or config.DEFAULT_CHAT_MODEL
-        return ChatOpenAI(
-            api_key = api_key,
-            model_name=model_name,
-            temperature = temperature
-        )
-    elif provider == "anthropic":
-        model_name = model or "claude-3-sonnet-20240229"
-        model_name = fit_anthropic_model(model_name=model_name)
-        return ChatAnthropic(
-            anthropic_api_key = SecretStr(api_key or ""),
-            model = model_name,
-            temperature = temperature
-        )
-    elif provider == "google":
-        model_name = model or  "gemini-2.5-pro"
-        return ChatGoogleGenerativeAI(
-            model=model_name,
-            google_api_key = config.GOOGLE_API,
-            temperature=temperature
-        )
 
 
-    elif provider in ("friendli", "lgai"):
-        model_name = model or "LGAI-EXAONE/EXAONE-4.0.1-32B"
-        return ChatOpenAI(
-            api_key=config.FRIENDLI_API,
-            model =model_name ,  # (endpoint_id)
-            base_url="https://api.friendli.ai/serverless/v1",
-            temperature=temperature
-        )
-    else:
-        raise ValueError(f"지원되지 않는 제공자: {provider}")
+def _parse_openai_models(raw_models: str) -> tuple[str, ...]:
+    models: Iterable[str] = (m.strip() for m in raw_models.split(","))
+    return tuple(sorted({m for m in models if m}))
 
 
-def get_backend_agent(provider="openai", model=None):
-    if provider == "openai":
-        model_name = model or config.DEFAULT_CHAT_MODEL
-        return ChatOpenAI(
-            openai_api_key=config.EMBEDDING_API,
-            model_name=model_name,
-            temperature=0.7
-        )
+@lru_cache(maxsize=1)
+def _openai_model_catalog() -> tuple[str, ...]:
+    return _parse_openai_models(config.OPENAI_MODELS or "") or (config.DEFAULT_CHAT_MODEL,)
+
+
+def _default_openai_model() -> str:
+    candidates = _openai_model_catalog()
+    preferred = config.DEFAULT_CHAT_MODEL.strip()
+    if preferred and preferred in candidates:
+        return preferred
+    return candidates[0]
+
+
+def ensure_openai_model(model: Optional[str]) -> str:
+    """Return a valid OpenAI 모델 이름."""
+
+    if model:
+        normalized = model.strip()
+        if normalized:
+            catalog = _openai_model_catalog()
+            if normalized in catalog:
+                return normalized
+    return _default_openai_model()
+
+
+def ensure_openai_provider(_: Optional[str]) -> str:
+    """현재 단계에서는 OpenAI 제공자만 허용한다."""
+
+    return "openai"
+
+
+def llm_kwargs_for_model(
+    *,
+    fast_response_mode: bool,
+    model_name: Optional[str] = None,
+    provider_name: Optional[str] = None,
+) -> dict:
+    """AI 모델 설정에서 사용할 LLM 파라미터를 반환한다."""
+
+    kwargs: dict = {
+        "provider": ensure_openai_provider(provider_name),
+        "model": ensure_openai_model(model_name),
+        "temperature": 0.2 if fast_response_mode else 0.3,
+    }
+    if fast_response_mode:
+        kwargs["max_tokens"] = 512
+    return kwargs
+
+
+def get_llm(
+    provider: str = "openai",
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    temperature: float = 0.7,
+    **kwargs,
+):
+    """지정된 사양에 맞는 OpenAI LLM 인스턴스를 생성한다."""
+
+    ensure_openai_provider(provider)
+    model_name = ensure_openai_model(model)
+    final_api_key = api_key or config.OPENAI_API or config.DEFAULT_API_KEY
+
+    return ChatOpenAI(
+        api_key=final_api_key,
+        model_name=model_name,
+        temperature=temperature,
+        **kwargs,
+    )
 

--- a/langchain_service/prompt/style.py
+++ b/langchain_service/prompt/style.py
@@ -25,8 +25,3 @@ def build_system_prompt(style: Style, **flags) -> str:
         STYLE_MAP[style],
         policy_text(**flags)
     ])
-
-
-def llm_params(fast_response_mode: bool) -> dict:
-    # 필요 시 조정
-    return {"temperature": 0.2, "max_tokens": 512} if fast_response_mode else {"temperature": 0.3}

--- a/service/qa_pipeline.py
+++ b/service/qa_pipeline.py
@@ -15,12 +15,17 @@ from langchain_service.chain.qa_chain import make_qa_chain
 from langchain_service.embedding.get_vector import text_to_vector
 from crud import chat as crud_chat
 from crud import knowledge as crud_knowledge
-from langchain_service.llm.setup import get_llm
+from langchain_service.llm.setup import get_llm, llm_kwargs_for_model
 
 
 class QAPipeline:
     def __init__(self, provider="openai", model="gpt-4o", api_key=None, top_k=3):
-        self.llm = get_llm(provider, model, api_key=api_key)
+        llm_options = llm_kwargs_for_model(
+            fast_response_mode=False,
+            model_name=model,
+            provider_name=provider,
+        )
+        self.llm = get_llm(api_key=api_key, **llm_options)
         self.top_k = top_k
 
         self.prompt = PromptTemplate(


### PR DESCRIPTION
## Summary
- centralize OpenAI model normalization and provider enforcement in `get_llm`
- ensure QA chain and pipeline request OpenAI chat models via the new helper
- simplify prompt utilities now that temperature handling lives with the LLM setup

## Testing
- python -m compileall langchain_service

------
https://chatgpt.com/codex/tasks/task_e_68dcc818580c8328b5a5eae8afc06493