### PR TITLE
feat: 활성 모델 운영 지표 연동

### DIFF
--- a/crud/analytics.py
+++ b/crud/analytics.py
@@ -156,6 +156,9 @@ def get_model_stats(db: Session, *, limit: int = 10, start: Optional[datetime] =
             Model.provider_name,
             sessions_col,
             func.coalesce(resp_agg.c.avg_ms, 0.0).label("avg_response_ms"),
+            Model.accuracy,
+            Model.uptime_percent,
+            Model.month_conversations,
         )
         .select_from(Model)
         .outerjoin(
@@ -164,7 +167,13 @@ def get_model_stats(db: Session, *, limit: int = 10, start: Optional[datetime] =
         )
         .outerjoin(resp_agg, resp_agg.c.mid == Model.id)
         .group_by(
-            Model.id, Model.name, Model.provider_name, resp_agg.c.avg_ms
+            Model.id,
+            Model.name,
+            Model.provider_name,
+            resp_agg.c.avg_ms,
+            Model.accuracy,
+            Model.uptime_percent,
+            Model.month_conversations,
         )
         .order_by(sessions_col.desc(), Model.id.asc())
         .limit(limit)
@@ -178,6 +187,9 @@ def get_model_stats(db: Session, *, limit: int = 10, start: Optional[datetime] =
             "provider": r.provider_name,
             "sessions": int(r.sessions or 0),
             "avg_response_ms": round(float(r.avg_response_ms or 0.0), 2),
+            "accuracy": round(float(r.accuracy or 0.0), 2),
+            "uptime_percent": round(float(r.uptime_percent or 0.0), 2),
+            "monthly_conversations": int(r.month_conversations or 0),
         }
         for r in rows
     ]

--- a/html/09.09 AI 모델 설정.html
+++ b/html/09.09 AI 모델 설정.html
@@ -1224,10 +1224,48 @@
                         throw new Error('활성화된 모델 정보를 찾을 수 없습니다.');
                     }
                     applyModelData(model, true);
+                    await fetchActiveModelAnalytics();
                     showNotification(`${state.modelName} 모델 설정이 준비되었습니다.`, 'success');
                 } catch (error) {
                     console.error('활성 모델 정보를 불러오는 중 오류가 발생했습니다.', error);
                     showNotification(error?.message || '활성 모델 정보를 불러오지 못했습니다.', 'error');
+                }
+            };
+
+            const fetchActiveModelAnalytics = async () => {
+                if (!state.activeModelId) {
+                    return;
+                }
+
+                try {
+                    const analytics = await fetchJSON(buildApiUrl('/analytics/models'));
+                    if (!Array.isArray(analytics) || analytics.length === 0) {
+                        return;
+                    }
+
+                    const activeMetrics = analytics.find(item => Number(item?.model_id) === Number(state.activeModelId));
+                    if (!activeMetrics) {
+                        return;
+                    }
+
+                    const updateMetricValue = (element, value, formatter) => {
+                        if (!element) {
+                            return;
+                        }
+                        if (value === undefined || value === null) {
+                            element.textContent = '데이터 없음';
+                            return;
+                        }
+                        element.textContent = formatter ? formatter(value) : String(value);
+                    };
+
+                    updateMetricValue(elements.responseTimeValue, activeMetrics.avg_response_ms, formatResponseTime);
+                    updateMetricValue(elements.monthlyConversationValue, activeMetrics.monthly_conversations, formatNumber);
+                    updateMetricValue(elements.accuracyValue, activeMetrics.accuracy, formatPercentage);
+                    updateMetricValue(elements.uptimeValue, activeMetrics.uptime_percent, formatPercentage);
+                } catch (error) {
+                    console.error('모델 운영 지표를 불러오는 중 오류가 발생했습니다.', error);
+                    showNotification('모델 운영 지표를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.', 'warning');
                 }
             };
 
@@ -1278,6 +1316,7 @@
 
                         if (updated) {
                             applyModelData(updated, true);
+                            await fetchActiveModelAnalytics();
                         } else {
                             state.initialSettings = gatherCurrentSettings();
                         }

--- a/schemas/analytics.py
+++ b/schemas/analytics.py
@@ -32,3 +32,6 @@ class ModelStat(BaseModel):
     provider: str
     sessions: int
     avg_response_ms: float
+    accuracy: float
+    uptime_percent: float
+    monthly_conversations: int


### PR DESCRIPTION
## Summary
- /analytics/models 응답에 정확도, 가동률, 월간 대화수를 포함하도록 백엔드 통계를 확장했습니다.
- 활성 모델을 불러올 때 운영 지표를 동기화하고, 값이 없을 때는 예외 처리를 통해 기본 정보나 안내 문구를 유지하도록 했습니다.

## Testing
- 테스트를 실행하지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_68dcd51edc84832899b401d45bc5dc18