### PR TITLE
Replace struct-web-wizard React entry with standalone HTML chat client

### DIFF
--- a/html/struct-web-wizard-main/index.html
+++ b/html/struct-web-wizard-main/index.html
@@ -1,24 +1,1077 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI 채팅방 - 카카오톡 스타일</title>
-    <meta name="description" content="카카오톡 스타일의 AI 채팅 인터페이스" />
-    <meta name="author" content="Lovable" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI 상담 챗봇</title>
+    <meta name="description" content="가람포스텍 RAG 상담 센터 웹 채팅" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+KR:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg-muted: #f4f6fb;
+        --bg-surface: #ffffff;
+        --border-subtle: #e2e8f0;
+        --border-strong: #cbd5f5;
+        --text-primary: #0f172a;
+        --text-secondary: #475569;
+        --text-tertiary: #94a3b8;
+        --accent: #2563eb;
+        --accent-soft: #eff6ff;
+        --assistant: #ede9fe;
+        --assistant-border: rgba(192, 132, 252, 0.4);
+        --assistant-text: #5b21b6;
+        --danger: #dc2626;
+        --success: #16a34a;
+        --warning: #f97316;
+        --shadow-sm: 0 10px 30px rgba(15, 23, 42, 0.08);
+        --shadow-md: 0 16px 40px rgba(30, 64, 175, 0.18);
+        --radius-lg: 20px;
+      }
 
-    <meta property="og:title" content="AI 채팅방" />
-    <meta property="og:description" content="카카오톡 스타일의 실시간 AI 채팅" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+      * {
+        box-sizing: border-box;
+      }
 
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg-muted);
+        font-family: "Inter", "Noto Sans KR", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--text-primary);
+      }
+
+      button {
+        font-family: inherit;
+      }
+
+      .chat-app {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .chat-header {
+        background: var(--bg-surface);
+        padding: 18px 28px;
+        border-bottom: 1px solid var(--border-subtle);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 24px;
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        box-shadow: 0 4px 18px rgba(15, 23, 42, 0.06);
+      }
+
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        min-width: 0;
+      }
+
+      .title-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .title-group h1 {
+        margin: 0;
+        font-size: 1.2rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+
+      .session-meta {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+      }
+
+      .session-id {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      .connection-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-size: 0.82rem;
+        background: rgba(148, 163, 184, 0.15);
+        color: var(--text-secondary);
+        transition: all 0.2s ease;
+      }
+
+      .connection-status .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--text-tertiary);
+        box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.25);
+        transition: all 0.2s ease;
+      }
+
+      .connection-status.success {
+        background: rgba(34, 197, 94, 0.18);
+        color: var(--success);
+      }
+
+      .connection-status.success .status-dot {
+        background: var(--success);
+        box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
+      }
+
+      .connection-status.error {
+        background: rgba(220, 38, 38, 0.12);
+        color: var(--danger);
+      }
+
+      .connection-status.error .status-dot {
+        background: var(--danger);
+        box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.18);
+      }
+
+      .connection-status.pending {
+        background: rgba(249, 115, 22, 0.12);
+        color: var(--warning);
+      }
+
+      .connection-status.pending .status-dot {
+        background: var(--warning);
+        box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2);
+        animation: pulse 1.4s infinite ease-in-out;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 0.6;
+        }
+        50% {
+          transform: scale(1.2);
+          opacity: 1;
+        }
+      }
+
+      .header-right {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      .input-chip {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border-subtle);
+        background: var(--accent-soft);
+        padding: 6px 12px;
+      }
+
+      .input-chip label {
+        font-size: 0.82rem;
+        color: var(--text-secondary);
+      }
+
+      .input-chip input {
+        border: none;
+        background: transparent;
+        font-size: 0.86rem;
+        min-width: 200px;
+        color: var(--text-primary);
+        outline: none;
+      }
+
+      .text-input {
+        border-radius: 12px;
+        border: 1px solid var(--border-subtle);
+        background: var(--bg-surface);
+        padding: 8px 12px;
+        font-size: 0.9rem;
+        outline: none;
+        min-width: 200px;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .text-input:focus {
+        border-color: rgba(37, 99, 235, 0.45);
+        box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+      }
+
+      .ghost-button,
+      .primary-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border-radius: 999px;
+        padding: 10px 18px;
+        font-weight: 600;
+        font-size: 0.9rem;
+        cursor: pointer;
+        border: none;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+      }
+
+      .ghost-button {
+        background: rgba(37, 99, 235, 0.1);
+        color: var(--accent);
+      }
+
+      .ghost-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+      }
+
+      .primary-button {
+        background: var(--accent);
+        color: white;
+        box-shadow: var(--shadow-sm);
+      }
+
+      .primary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-md);
+      }
+
+      .primary-button[disabled] {
+        opacity: 0.6;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      .primary-button .spinner {
+        width: 18px;
+        height: 18px;
+        border: 2px solid rgba(255, 255, 255, 0.6);
+        border-top-color: white;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .chat-main {
+        flex: 1;
+        overflow-y: auto;
+        padding: 28px 18px 34px;
+      }
+
+      .chat-main-inner {
+        max-width: 780px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 80px 16px;
+        color: var(--text-secondary);
+        border-radius: var(--radius-lg);
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        background: rgba(241, 245, 249, 0.6);
+        margin-top: 40px;
+      }
+
+      .empty-state h2 {
+        margin: 12px 0 8px;
+        font-size: 1.4rem;
+      }
+
+      .empty-state p {
+        margin: 0;
+        font-size: 0.95rem;
+      }
+
+      .messages {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .message-row {
+        display: flex;
+        gap: 14px;
+        align-items: flex-end;
+      }
+
+      .message-row.user {
+        flex-direction: row-reverse;
+      }
+
+      .avatar {
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        color: white;
+        background: var(--accent);
+        box-shadow: 0 10px 22px rgba(37, 99, 235, 0.25);
+        flex-shrink: 0;
+      }
+
+      .message-row.assistant .avatar {
+        background: rgba(109, 40, 217, 0.12);
+        color: var(--assistant-text);
+        box-shadow: none;
+      }
+
+      .message-bubble {
+        max-width: min(72%, 600px);
+        padding: 16px 20px;
+        border-radius: 24px;
+        font-size: 0.98rem;
+        line-height: 1.65;
+        letter-spacing: -0.01em;
+        box-shadow: 0 16px 45px rgba(15, 23, 42, 0.1);
+        word-break: break-word;
+        white-space: pre-wrap;
+      }
+
+      .message-row.user .message-bubble {
+        background: var(--accent);
+        color: white;
+        box-shadow: 0 18px 38px rgba(37, 99, 235, 0.28);
+      }
+
+      .message-row.assistant .message-bubble {
+        background: var(--bg-surface);
+        border: 1px solid rgba(226, 232, 240, 0.85);
+        box-shadow: 0 16px 45px rgba(15, 23, 42, 0.08);
+        color: var(--text-primary);
+      }
+
+      .message-bubble.typing {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        background: var(--assistant);
+        border: 1px solid var(--assistant-border);
+        box-shadow: none;
+      }
+
+      .typing-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: rgba(91, 33, 182, 0.7);
+        animation: blink 1.2s infinite ease-in-out;
+      }
+
+      .typing-dot:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+
+      .typing-dot:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+
+      @keyframes blink {
+        0%,
+        80%,
+        100% {
+          opacity: 0.2;
+          transform: translateY(0);
+        }
+        40% {
+          opacity: 1;
+          transform: translateY(-4px);
+        }
+      }
+
+      .chat-footer {
+        background: var(--bg-surface);
+        border-top: 1px solid var(--border-subtle);
+        padding: 18px 20px 22px;
+        position: sticky;
+        bottom: 0;
+        z-index: 15;
+      }
+
+      .footer-inner {
+        max-width: 780px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+
+      .footer-top {
+        display: flex;
+        gap: 12px;
+        align-items: flex-end;
+        flex-wrap: wrap;
+      }
+
+      .footer-top textarea {
+        flex: 1;
+        min-height: 90px;
+        max-height: 200px;
+        resize: vertical;
+        padding: 16px 18px;
+        border-radius: 20px;
+        border: 1px solid rgba(203, 213, 225, 0.9);
+        background: #f8fafc;
+        font-size: 0.96rem;
+        line-height: 1.65;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+        outline: none;
+      }
+
+      .footer-top textarea:focus {
+        border-color: rgba(37, 99, 235, 0.6);
+        box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+        background: white;
+      }
+
+      .footer-bottom {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .footer-bottom .options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .option-chip {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-radius: 14px;
+        background: rgba(15, 23, 42, 0.03);
+        border: 1px solid rgba(226, 232, 240, 0.9);
+      }
+
+      .option-chip select,
+      .option-chip input {
+        border: none;
+        background: transparent;
+        font-size: 0.86rem;
+        outline: none;
+        min-width: 70px;
+      }
+
+      .option-chip select {
+        padding-right: 4px;
+      }
+
+      .option-chip input {
+        width: 110px;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      .toast-container {
+        position: fixed;
+        top: 24px;
+        right: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        z-index: 1000;
+      }
+
+      .toast {
+        min-width: 240px;
+        padding: 14px 18px;
+        border-radius: 16px;
+        color: white;
+        font-size: 0.92rem;
+        box-shadow: 0 20px 48px rgba(15, 23, 42, 0.18);
+        opacity: 0;
+        transform: translateY(-12px);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+      }
+
+      .toast.visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .toast.info {
+        background: rgba(15, 23, 42, 0.92);
+      }
+
+      .toast.success {
+        background: rgba(22, 163, 74, 0.92);
+      }
+
+      .toast.error {
+        background: rgba(220, 38, 38, 0.92);
+      }
+
+      .toast.warning {
+        background: rgba(249, 115, 22, 0.92);
+      }
+
+      @media (max-width: 960px) {
+        .chat-header {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .header-right {
+          justify-content: flex-start;
+        }
+
+        .footer-top {
+          flex-direction: column;
+        }
+
+        .primary-button {
+          align-self: flex-end;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .chat-header {
+          padding: 16px;
+        }
+
+        .chat-main {
+          padding: 24px 12px 30px;
+        }
+
+        .footer-inner {
+          padding: 0;
+        }
+
+        .option-chip input {
+          width: 90px;
+        }
+      }
+    </style>
   </head>
-
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div class="chat-app">
+      <header class="chat-header">
+        <div class="header-left">
+          <button class="ghost-button" id="newSessionButton">+ 새 대화</button>
+          <div class="title-group">
+            <h1>AI 상담 챗봇</h1>
+            <div class="session-meta">
+              <span>세션</span>
+              <span class="session-id" id="sessionId">-</span>
+              <span class="connection-status" id="connectionStatus">
+                <span class="status-dot"></span>
+                <span id="connectionStatusText">연결 대기</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="header-right">
+          <input
+            class="text-input"
+            id="sessionTitleInput"
+            type="text"
+            placeholder="세션 제목을 입력하세요"
+            autocomplete="off"
+          />
+          <div class="input-chip">
+            <label for="apiBaseInput">API</label>
+            <input id="apiBaseInput" type="text" placeholder="http://localhost:5000" autocomplete="off" />
+          </div>
+          <button class="ghost-button" id="checkConnectionButton">연결 확인</button>
+        </div>
+      </header>
+
+      <main class="chat-main" id="chatMain">
+        <div class="chat-main-inner">
+          <div class="empty-state" id="emptyState">
+            <div style="font-size: 48px">💬</div>
+            <h2>대화를 시작해보세요</h2>
+            <p>문의하고 싶은 내용을 입력하면 AI 상담원이 바로 답변해 드립니다.</p>
+          </div>
+          <div class="messages" id="messages"></div>
+        </div>
+      </main>
+
+      <footer class="chat-footer">
+        <div class="footer-inner">
+          <div class="footer-top">
+            <textarea
+              id="messageInput"
+              placeholder="메시지를 입력하고 Enter 키로 전송해보세요. 줄바꿈은 Shift + Enter"
+            ></textarea>
+            <button class="primary-button" id="sendButton">
+              <span>전송</span>
+            </button>
+          </div>
+          <div class="footer-bottom">
+            <div class="options">
+              <div class="option-chip">
+                <span>검색 Top-K</span>
+                <select id="topKSelect">
+                  <option value="3">3</option>
+                  <option value="5" selected>5</option>
+                  <option value="7">7</option>
+                  <option value="10">10</option>
+                </select>
+              </div>
+              <div class="option-chip">
+                <span>지식베이스</span>
+                <select id="knowledgeSelect">
+                  <option value="">전체</option>
+                </select>
+              </div>
+            </div>
+            <div class="options">
+              <div class="option-chip">
+                <span>응답 언어</span>
+                <span>한국어</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <div class="toast-container" id="toastContainer"></div>
+
+    <script type="module">
+      const state = {
+        baseUrl: "",
+        sessionId: null,
+        isSending: false,
+        typingEl: null,
+        previewUpdated: false,
+      };
+
+      const elements = {
+        sessionId: document.getElementById("sessionId"),
+        sessionTitle: document.getElementById("sessionTitleInput"),
+        connectionStatus: document.getElementById("connectionStatus"),
+        connectionStatusText: document.getElementById("connectionStatusText"),
+        apiBaseInput: document.getElementById("apiBaseInput"),
+        checkConnectionButton: document.getElementById("checkConnectionButton"),
+        newSessionButton: document.getElementById("newSessionButton"),
+        messageInput: document.getElementById("messageInput"),
+        sendButton: document.getElementById("sendButton"),
+        messages: document.getElementById("messages"),
+        emptyState: document.getElementById("emptyState"),
+        toastContainer: document.getElementById("toastContainer"),
+        topKSelect: document.getElementById("topKSelect"),
+        knowledgeSelect: document.getElementById("knowledgeSelect"),
+        chatMain: document.getElementById("chatMain"),
+      };
+
+      const STORAGE_KEYS = {
+        BASE_URL: "chat_api_base_url",
+        SESSION_TITLE: "chat_session_title",
+      };
+
+      function sanitizeBaseUrl(value) {
+        return value.trim().replace(/\/+$/, "");
+      }
+
+      function scrollToBottom() {
+        requestAnimationFrame(() => {
+          elements.chatMain.scrollTo({
+            top: elements.chatMain.scrollHeight,
+            behavior: "smooth",
+          });
+        });
+      }
+
+      function showToast(message, variant = "info", duration = 4000) {
+        const toast = document.createElement("div");
+        toast.className = `toast ${variant}`;
+        toast.textContent = message;
+        elements.toastContainer.appendChild(toast);
+        requestAnimationFrame(() => toast.classList.add("visible"));
+        setTimeout(() => {
+          toast.classList.remove("visible");
+          setTimeout(() => toast.remove(), 300);
+        }, duration);
+      }
+
+      function setConnectionStatus(type, message) {
+        elements.connectionStatus.classList.remove("success", "error", "pending");
+        if (type) {
+          elements.connectionStatus.classList.add(type);
+        }
+        elements.connectionStatusText.textContent = message;
+      }
+
+      function updateSessionDisplay() {
+        elements.sessionId.textContent = state.sessionId ? `#${state.sessionId}` : "-";
+      }
+
+      function updateEmptyState() {
+        const hasMessages = elements.messages.children.length > 0;
+        elements.emptyState.classList.toggle("hidden", hasMessages);
+      }
+
+      function setSendingState(isSending) {
+        state.isSending = isSending;
+        elements.sendButton.disabled = isSending;
+        elements.messageInput.disabled = isSending;
+        if (isSending) {
+          elements.sendButton.innerHTML = '<span class="spinner"></span><span>전송 중...</span>';
+        } else {
+          elements.sendButton.innerHTML = "<span>전송</span>";
+        }
+      }
+
+      function createAvatar(role) {
+        const avatar = document.createElement("div");
+        avatar.className = "avatar";
+        avatar.textContent = role === "user" ? "나" : "AI";
+        return avatar;
+      }
+
+      function appendMessage(role, content) {
+        const row = document.createElement("div");
+        row.className = `message-row ${role === "user" ? "user" : "assistant"}`;
+
+        const avatar = createAvatar(role);
+        const bubble = document.createElement("div");
+        bubble.className = "message-bubble";
+        bubble.textContent = content;
+
+        row.appendChild(avatar);
+        row.appendChild(bubble);
+        elements.messages.appendChild(row);
+        updateEmptyState();
+        scrollToBottom();
+        return row;
+      }
+
+      function showTypingIndicator() {
+        if (state.typingEl) return state.typingEl;
+        const row = document.createElement("div");
+        row.className = "message-row assistant";
+        const avatar = createAvatar("assistant");
+        const bubble = document.createElement("div");
+        bubble.className = "message-bubble typing";
+        bubble.innerHTML = '<span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span>';
+        row.appendChild(avatar);
+        row.appendChild(bubble);
+        elements.messages.appendChild(row);
+        state.typingEl = row;
+        updateEmptyState();
+        scrollToBottom();
+        return row;
+      }
+
+      function hideTypingIndicator() {
+        if (state.typingEl && state.typingEl.parentElement) {
+          state.typingEl.parentElement.removeChild(state.typingEl);
+        }
+        state.typingEl = null;
+        updateEmptyState();
+      }
+
+      async function parseError(response) {
+        const fallback = `${response.status} ${response.statusText}`.trim();
+        try {
+          const data = await response.clone().json();
+          if (typeof data === "string") return data;
+          if (data.detail) {
+            if (typeof data.detail === "string") return data.detail;
+            if (Array.isArray(data.detail)) {
+              return data.detail
+                .map((item) => item.msg || item.message || (typeof item === "string" ? item : JSON.stringify(item)))
+                .join(", ");
+            }
+            if (typeof data.detail === "object") {
+              return data.detail.message || JSON.stringify(data.detail);
+            }
+          }
+          if (data.message) return data.message;
+          return JSON.stringify(data);
+        } catch (error) {
+          try {
+            const text = await response.clone().text();
+            return text || fallback;
+          } catch {
+            return fallback || "요청 처리에 실패했습니다.";
+          }
+        }
+      }
+
+      async function loadKnowledgeOptions() {
+        if (!state.baseUrl) return;
+        try {
+          const response = await fetch(`${state.baseUrl}/knowledge?offset=0&limit=100`);
+          if (!response.ok) return;
+          const items = await response.json();
+          elements.knowledgeSelect.innerHTML = '<option value="">전체</option>';
+          items.forEach((item) => {
+            const option = document.createElement("option");
+            const label = item.original_name || item.preview || `지식베이스 ${item.id}`;
+            option.value = String(item.id);
+            option.textContent = `#${item.id} · ${label}`;
+            elements.knowledgeSelect.appendChild(option);
+          });
+        } catch (error) {
+          console.error("지식베이스 목록을 불러오지 못했습니다.", error);
+        }
+      }
+
+      async function checkConnection() {
+        if (!state.baseUrl) {
+          showToast("API 주소를 입력해주세요.", "warning");
+          return;
+        }
+        setConnectionStatus("pending", "연결 확인 중...");
+        try {
+          const response = await fetch(`${state.baseUrl}/chat/sessions?limit=1`);
+          if (!response.ok) {
+            const message = await parseError(response);
+            throw new Error(message);
+          }
+          setConnectionStatus("success", "API 연결 성공");
+          showToast("API에 정상적으로 연결되었습니다.", "success");
+          await loadKnowledgeOptions();
+        } catch (error) {
+          console.error(error);
+          setConnectionStatus("error", "API 연결 실패");
+          showToast(error.message || "API 연결에 실패했습니다.", "error");
+        }
+      }
+
+      async function ensureSession() {
+        if (state.sessionId) return state.sessionId;
+        if (!state.baseUrl) {
+          showToast("API 주소를 먼저 설정해주세요.", "warning");
+          throw new Error("API base URL is missing");
+        }
+        const title = (elements.sessionTitle.value || "웹 채팅 세션").trim();
+        try {
+          const response = await fetch(`${state.baseUrl}/chat/sessions`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ title, preview: "", resolved: false }),
+          });
+          if (!response.ok) {
+            const message = await parseError(response);
+            throw new Error(message);
+          }
+          const data = await response.json();
+          state.sessionId = data.id;
+          state.previewUpdated = false;
+          updateSessionDisplay();
+          showToast(`새 채팅 세션이 생성되었습니다. (#${state.sessionId})`, "success", 3000);
+          return state.sessionId;
+        } catch (error) {
+          showToast(error.message || "세션 생성에 실패했습니다.", "error");
+          throw error;
+        }
+      }
+
+      async function storeMessage(role, content, latencyMs = null) {
+        if (!state.sessionId) return;
+        try {
+          const response = await fetch(`${state.baseUrl}/chat/sessions/${state.sessionId}/messages`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              session_id: state.sessionId,
+              role,
+              content,
+              response_latency_ms: latencyMs,
+            }),
+          });
+          if (!response.ok) {
+            const message = await parseError(response);
+            throw new Error(message);
+          }
+        } catch (error) {
+          console.warn("메시지 저장 실패", error);
+          showToast(error.message || "메시지 저장에 실패했습니다.", "warning");
+        }
+      }
+
+      async function updatePreviewIfNeeded(userMessage) {
+        if (state.previewUpdated || !state.sessionId) return;
+        try {
+          const response = await fetch(`${state.baseUrl}/chat/sessions/${state.sessionId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              title: (elements.sessionTitle.value || "웹 채팅 세션").trim(),
+              preview: userMessage.slice(0, 120),
+            }),
+          });
+          if (response.ok) {
+            state.previewUpdated = true;
+          }
+        } catch (error) {
+          console.warn("세션 미리보기 업데이트 실패", error);
+        }
+      }
+
+      async function requestAssistantAnswer(question) {
+        const topK = Number(elements.topKSelect.value) || 5;
+        const knowledgeValue = elements.knowledgeSelect.value;
+        const payload = {
+          question,
+          top_k: topK,
+          knowledge_id: knowledgeValue ? Number(knowledgeValue) : null,
+        };
+        const response = await fetch(`${state.baseUrl}/llm/chat/sessions/${state.sessionId}/qa`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const message = await parseError(response);
+          throw new Error(message);
+        }
+        return response.json();
+      }
+
+      async function handleSend() {
+        if (state.isSending) return;
+        const message = elements.messageInput.value.trim();
+        if (!message) {
+          showToast("메시지를 입력해주세요.", "warning");
+          return;
+        }
+        elements.messageInput.value = "";
+        setSendingState(true);
+        try {
+          await ensureSession();
+        } catch (error) {
+          setSendingState(false);
+          return;
+        }
+
+        appendMessage("user", message);
+        await updatePreviewIfNeeded(message);
+        await storeMessage("user", message);
+
+        showTypingIndicator();
+        const start = performance.now();
+        try {
+          const data = await requestAssistantAnswer(message);
+          hideTypingIndicator();
+          const answer = data.answer?.trim?.() ? data.answer.trim() : "응답을 가져올 수 없습니다.";
+          appendMessage("assistant", answer);
+          const latency = Math.round(performance.now() - start);
+          await storeMessage("assistant", answer, latency);
+        } catch (error) {
+          hideTypingIndicator();
+          console.error("LLM 호출 오류", error);
+          appendMessage("assistant", error.message || "답변을 가져오지 못했습니다.");
+          showToast(error.message || "답변 생성 중 오류가 발생했습니다.", "error");
+        } finally {
+          setSendingState(false);
+        }
+      }
+
+      function resetConversation({ keepBase = true } = {}) {
+        if (!keepBase) {
+          state.baseUrl = "";
+          elements.apiBaseInput.value = "";
+          localStorage.removeItem(STORAGE_KEYS.BASE_URL);
+        }
+        state.sessionId = null;
+        state.previewUpdated = false;
+        updateSessionDisplay();
+        elements.messages.innerHTML = "";
+        hideTypingIndicator();
+        updateEmptyState();
+        setSendingState(false);
+      }
+
+      elements.sendButton.addEventListener("click", handleSend);
+      elements.messageInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          handleSend();
+        }
+      });
+
+      elements.checkConnectionButton.addEventListener("click", () => {
+        checkConnection();
+      });
+
+      elements.newSessionButton.addEventListener("click", async () => {
+        resetConversation();
+        if (!state.baseUrl) {
+          showToast("API 주소를 먼저 설정해주세요.", "warning");
+          return;
+        }
+        try {
+          await ensureSession();
+        } catch (error) {
+          // already handled
+        }
+      });
+
+      elements.apiBaseInput.addEventListener("change", () => {
+        const value = sanitizeBaseUrl(elements.apiBaseInput.value);
+        state.baseUrl = value;
+        elements.apiBaseInput.value = value;
+        if (value) {
+          localStorage.setItem(STORAGE_KEYS.BASE_URL, value);
+        } else {
+          localStorage.removeItem(STORAGE_KEYS.BASE_URL);
+        }
+        resetConversation();
+        setConnectionStatus("", "연결 대기");
+      });
+
+      elements.sessionTitle.addEventListener("change", () => {
+        const value = elements.sessionTitle.value.trim();
+        if (value) {
+          localStorage.setItem(STORAGE_KEYS.SESSION_TITLE, value);
+        } else {
+          localStorage.removeItem(STORAGE_KEYS.SESSION_TITLE);
+        }
+      });
+
+      function restorePreferences() {
+        const savedBase = localStorage.getItem(STORAGE_KEYS.BASE_URL) || "http://localhost:5000";
+        state.baseUrl = sanitizeBaseUrl(savedBase);
+        elements.apiBaseInput.value = state.baseUrl;
+        const savedTitle = localStorage.getItem(STORAGE_KEYS.SESSION_TITLE) || "웹 채팅 세션";
+        elements.sessionTitle.value = savedTitle;
+      }
+
+      restorePreferences();
+      updateEmptyState();
+      updateSessionDisplay();
+      if (state.baseUrl) {
+        checkConnection();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild `html/struct-web-wizard-main/index.html` as a standalone chat UI that runs without a React/Vite build step
- integrate the client with the existing FastAPI endpoints for session creation, message logging, and LLM QA responses
- add connection checks, knowledge base selection, and local storage of API settings for easier reuse

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ddd478c1348328a45a0ba2f315a848