### PR TITLE
Fix chat session endpoint path in web wizard UI

### DIFF
--- a/html/struct-web-wizard-main/index.html
+++ b/html/struct-web-wizard-main/index.html
@@ -945,7 +945,7 @@
           top_k: topK,
           knowledge_id: knowledgeValue ? Number(knowledgeValue) : null,
         };
-        const response = await fetch(`${state.baseUrl}/llm/chat/sessions/${state.sessionId}/qa`, {
+        const response = await fetch(`${state.baseUrl}/chat/sessions/${state.sessionId}/qa`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- update the requestAssistantAnswer fetch call to use the backend `/chat/sessions/` route
- verified there are no remaining references to the old `/llm/chat/sessions/` path

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddda631bac832888de6828ab477e16